### PR TITLE
[BE] ✨ DB Flyway 추가 및 엔티티 작성

### DIFF
--- a/apps/backend/src/main/java/resources/db/migration/V1__agiler_init.sql
+++ b/apps/backend/src/main/java/resources/db/migration/V1__agiler_init.sql
@@ -1,0 +1,192 @@
+CREATE TABLE `user` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `vendor` VARCHAR(20),
+    `vendor_id` VARCHAR(50),
+    `email` VARCHAR(40),
+    `nickname` VARCHAR(20) NOT NULL,
+    `img_id` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `project` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `title` VARCHAR(20) NOT NULL,
+    `summary` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `user_project` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `user_id` BIGINT NOT NULL,
+    `project_id` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`user_id`) REFERENCES `user`(`id`),
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `profile` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `user_id` BIGINT NOT NULL,
+    `project_id` BIGINT NOT NULL,
+    `nickname` VARCHAR(20),
+    `role` ENUM('member', 'owner') NOT NULL,
+    `img_id` BIGINT NOT NULL,
+    `email` TEXT,
+    `description` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`user_id`) REFERENCES `user`(`id`),
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `kanban_config` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT,
+    `status_name` VARCHAR(20) NOT NULL,
+    `priority` INT NOT NULL,
+    `default_status` TINYINT(1) NOT NULL,
+    `backlog` TINYINT(1) NOT NULL,
+    `is_done` TINYINT(1) NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `issue` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `kanban_config_id` BIGINT NOT NULL,
+    `profile_id` BIGINT,
+    `title` VARCHAR(20) NOT NULL,
+    `is_done` TINYINT(1) NOT NULL,
+    `contents` TEXT,
+    `started_at` DATETIME,
+    `due_at` DATETIME,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`kanban_config_id`) REFERENCES `kanban_config`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `image` (
+    `profile_id` BIGINT PRIMARY KEY,
+    `url` TEXT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `label` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT NOT NULL,
+    `name` VARCHAR(20) NOT NULL,
+    `color` VARCHAR(20) NOT NULL,
+    `description` VARCHAR(100),
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `issue_label` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `issue_id` BIGINT NOT NULL,
+    `label_id` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`issue_id`) REFERENCES `issue`(`id`),
+    FOREIGN KEY (`label_id`) REFERENCES `label`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `issue_status_history` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `issue_id` BIGINT NOT NULL,
+    `profile_id` BIGINT NOT NULL,
+    `from_kanban_config` BIGINT NOT NULL,
+    `to_kanban_config` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`issue_id`) REFERENCES `issue`(`id`),
+    FOREIGN KEY (`profile_id`) REFERENCES `profile`(`id`),
+    FOREIGN KEY (`from_kanban_config`) REFERENCES `kanban_config`(`id`),
+    FOREIGN KEY (`to_kanban_config`) REFERENCES `kanban_config`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `note` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT NOT NULL,
+    `type` ENUM('retro', 'issue', 'scrum', 'meeting') NOT NULL,
+    `title` VARCHAR(20) NOT NULL,
+    `contents` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `note_profile` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `note_id` BIGINT NOT NULL,
+    `profile_id` BIGINT NOT NULL,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`note_id`) REFERENCES `note`(`id`),
+    FOREIGN KEY (`profile_id`) REFERENCES `profile`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `retro_template` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT NOT NULL,
+    `title` VARCHAR(20) NOT NULL,
+    `description` VARCHAR(100),
+    `contents` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `issue_template` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT NOT NULL,
+    `title` VARCHAR(20) NOT NULL,
+    `description` VARCHAR(100),
+    `contents` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `scrum_template` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT NOT NULL,
+    `title` VARCHAR(20) NOT NULL,
+    `description` VARCHAR(100),
+    `contents` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `meeting_template` (
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `project_id` BIGINT NOT NULL,
+    `title` VARCHAR(20) NOT NULL,
+    `contents` TEXT,
+    `created_at` DATETIME NOT NULL,
+    `updated_at` DATETIME NOT NULL,
+    `deleted_at` DATETIME,
+    FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/AgilerApplication.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/AgilerApplication.java
@@ -2,8 +2,10 @@ package scrumpledpaper.agiler;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AgilerApplication {
 
 	public static void main(String[] args) {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/BaseEntity.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/BaseEntity.java
@@ -1,0 +1,28 @@
+package scrumpledpaper.agiler.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+	@CreatedDate
+	@Column(name = "created_at", updatable = false, nullable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/BaseEntity.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/BaseEntity.java
@@ -2,6 +2,8 @@ package scrumpledpaper.agiler.common;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -14,6 +16,8 @@ import lombok.Getter;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@SQLDelete(sql = "UPDATE {h-table} SET deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
 public abstract class BaseEntity {
 	@CreatedDate
 	@Column(name = "created_at", updatable = false, nullable = false)

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
@@ -2,6 +2,8 @@ package scrumpledpaper.agiler.image.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -14,6 +16,10 @@ import scrumpledpaper.agiler.common.BaseEntity;
 @Table(name = "image")
 public class Image extends BaseEntity {
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
 	@Column(name = "profile_id")
 	private Long profileId;
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
@@ -1,0 +1,22 @@
+package scrumpledpaper.agiler.image.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "image")
+public class Image extends BaseEntity {
+	@Id
+	@Column(name = "profile_id")
+	private Long profileId;
+
+	@Column(name = "url", nullable = false)
+	private String url;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/repository/ImageRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.image.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Issue.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Issue.java
@@ -1,0 +1,50 @@
+package scrumpledpaper.agiler.kanban.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.user.entity.Profile;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "issue")
+public class Issue extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "kanban_config_id")
+	private KanbanConfig kanbanConfig;
+
+	@ManyToOne
+	@JoinColumn(name = "profile_id")
+	private Profile profile;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "is_done", nullable = false)
+	private boolean done;
+
+	@Column(name = "contents")
+	private String contents;
+
+	@Column(name = "started_at")
+	private LocalDateTime startedAt;
+
+	@Column(name = "due_at")
+	private LocalDateTime dueAt;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/IssueLabel.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/IssueLabel.java
@@ -1,0 +1,32 @@
+package scrumpledpaper.agiler.kanban.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "issue_label")
+public class IssueLabel extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "issue_id")
+	private Issue issue;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "label_id")
+	private Label label;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/IssueStatusHistory.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/IssueStatusHistory.java
@@ -1,0 +1,41 @@
+package scrumpledpaper.agiler.kanban.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.user.entity.Profile;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "issue_status_history")
+public class IssueStatusHistory extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "issue_id")
+	private Issue issue;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "profile_id")
+	private Profile profile;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "from_kanban_config")
+	private KanbanConfig fromKanbanConfig;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "to_kanban_config")
+	private KanbanConfig toKanbanConfig;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/KanbanConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/KanbanConfig.java
@@ -1,0 +1,44 @@
+package scrumpledpaper.agiler.kanban.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "kanban_config")
+public class KanbanConfig extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "status_name", nullable = false)
+	private String statusName;
+
+	@Column(name = "priority", nullable = false)
+	private int priority;
+
+	@Column(name = "default_status", nullable = false)
+	private boolean defaultStatus;
+
+	@Column(name = "backlog", nullable = false)
+	private boolean backlog;
+
+	@Column(name = "is_done", nullable = false)
+	private boolean done;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Label.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Label.java
@@ -1,0 +1,38 @@
+package scrumpledpaper.agiler.kanban.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "label")
+public class Label extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "color", nullable = false)
+	private String color;
+
+	@Column(name = "description")
+	private String description;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueLabelRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueLabelRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.kanban.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.kanban.entity.IssueLabel;
+
+public interface IssueLabelRepository extends JpaRepository<IssueLabel, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.kanban.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.kanban.entity.Issue;
+
+public interface IssueRepository extends JpaRepository<Issue, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueStatusHistoryRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueStatusHistoryRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.kanban.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.kanban.entity.IssueStatusHistory;
+
+public interface IssueStatusHistoryRepository extends JpaRepository<IssueStatusHistory, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/KanbanConfigRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/KanbanConfigRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.kanban.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.kanban.entity.KanbanConfig;
+
+public interface KanbanConfigRepository extends JpaRepository<KanbanConfig, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/LabelRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/LabelRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.kanban.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.kanban.entity.Label;
+
+public interface LabelRepository extends JpaRepository<Label, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/Note.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/Note.java
@@ -1,0 +1,43 @@
+package scrumpledpaper.agiler.note.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "note")
+public class Note extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "type", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private NoteType type;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "contents")
+	private String contents;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteProfile.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteProfile.java
@@ -1,0 +1,33 @@
+package scrumpledpaper.agiler.note.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.user.entity.Profile;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "note_profile")
+public class NoteProfile extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "note_id")
+	private Note note;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "profile_id")
+	private Profile profile;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteType.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteType.java
@@ -2,7 +2,6 @@ package scrumpledpaper.agiler.note.entity;
 
 public enum NoteType {
 	retro,
-	issue,
 	scrum,
 	meeting
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteType.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteType.java
@@ -1,0 +1,8 @@
+package scrumpledpaper.agiler.note.entity;
+
+public enum NoteType {
+	retro,
+	issue,
+	scrum,
+	meeting
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/NoteProfileRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/NoteProfileRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.note.entity.NoteProfile;
+
+public interface NoteProfileRepository extends JpaRepository<NoteProfile, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/NoteRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/NoteRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.note.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.note.entity.Note;
+
+public interface NoteRepository extends JpaRepository<Note, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/Project.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/Project.java
@@ -1,0 +1,28 @@
+package scrumpledpaper.agiler.project.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "project")
+public class Project extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "summary")
+	private String summary;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/UserProject.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/UserProject.java
@@ -12,13 +12,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.common.BaseEntity;
 import scrumpledpaper.agiler.user.entity.User;
 
 @Getter
 @NoArgsConstructor
 @Entity
 @Table(name = "user_project")
-public class UserProject {
+public class UserProject extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
@@ -31,13 +32,4 @@ public class UserProject {
 	@ManyToOne(optional = false)
 	@JoinColumn(name = "project_id")
 	private Project project;
-
-	@Column(name = "created_at", nullable = false)
-	private LocalDateTime createdAt;
-
-	@Column(name = "modified_at", nullable = false)
-	private LocalDateTime updatedAt;
-
-	@Column(name = "deleted_at")
-	private LocalDateTime deletedAt;
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/UserProject.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/UserProject.java
@@ -1,0 +1,43 @@
+package scrumpledpaper.agiler.project.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.user.entity.User;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "user_project")
+public class UserProject {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt;
+
+	@Column(name = "modified_at", nullable = false)
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/repository/ProjectRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/repository/ProjectRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.project.entity.Project;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/IssueTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/IssueTemplate.java
@@ -1,0 +1,38 @@
+package scrumpledpaper.agiler.template.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "issue_template")
+public class IssueTemplate extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "contents")
+	private String contents;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/MeetingTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/MeetingTemplate.java
@@ -1,0 +1,35 @@
+package scrumpledpaper.agiler.template.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "meeting_template")
+public class MeetingTemplate extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "contents")
+	private String contents;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/RetroTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/RetroTemplate.java
@@ -1,0 +1,38 @@
+package scrumpledpaper.agiler.template.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "retro_template")
+public class RetroTemplate extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "contents")
+	private String contents;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/ScrumTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/ScrumTemplate.java
@@ -1,0 +1,38 @@
+package scrumpledpaper.agiler.template.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "scrum_template")
+public class ScrumTemplate extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "project_id")
+	private Project project;
+
+	@Column(name = "title", nullable = false)
+	private String title;
+
+	@Column(name = "description")
+	private String description;
+
+	@Column(name = "contents")
+	private String contents;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/IssueTemplateRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/IssueTemplateRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.template.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.template.entity.IssueTemplate;
+
+public interface IssueTemplateRepository extends JpaRepository<IssueTemplate, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/MeetingTemplateRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/MeetingTemplateRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.template.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
+
+public interface MeetingTemplateRepository extends JpaRepository<MeetingTemplate, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/RetroTemplateRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/RetroTemplateRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.template.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.template.entity.RetroTemplate;
+
+public interface RetroTemplateRepository extends JpaRepository<RetroTemplate, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/ScrumTemplateRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/ScrumTemplateRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.template.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.template.entity.ScrumTemplate;
+
+public interface ScrumTemplateRepository extends JpaRepository<ScrumTemplate, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/Profile.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/Profile.java
@@ -1,0 +1,51 @@
+package scrumpledpaper.agiler.user.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "profile")
+public class Profile extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@ManyToOne(optional = false)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne
+	@JoinColumn(name = "project_id", nullable = false)
+	private Project project;
+
+	@Column(name = "nickname")
+	private String nickname;
+
+	@Column(name = "role", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Role role;
+
+	@Column(name = "img_id", nullable = false)
+	private long imgId;
+
+	@Column(name = "email")
+	private String email;
+
+	@Column(name = "description")
+	private String description;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/Role.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/Role.java
@@ -1,0 +1,6 @@
+package scrumpledpaper.agiler.user.entity;
+
+public enum Role {
+	member,
+	owner
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
@@ -1,0 +1,38 @@
+package scrumpledpaper.agiler.user.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.common.BaseEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "user")
+public class User extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "vendor")
+	private String vendor;
+
+	@Column(name = "vendor_id", nullable = false)
+	private String vendorId;
+
+	@Column(name = "email")
+	private String email;
+
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
+
+	@Column(name = "img_id", nullable = false)
+	private long imgId;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/ProfileRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/ProfileRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.user.entity.Profile;
+
+public interface ProfileRepository extends JpaRepository<Profile, Long> {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
+++ b/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
@@ -189,4 +189,4 @@ CREATE TABLE `meeting_template` (
     `updated_at` DATETIME NOT NULL,
     `deleted_at` DATETIME,
     FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci; 

--- a/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
+++ b/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
@@ -124,7 +124,7 @@ CREATE TABLE `issue_status_history` (
 CREATE TABLE `note` (
     `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
     `project_id` BIGINT NOT NULL,
-    `type` ENUM('retro', 'issue', 'scrum', 'meeting') NOT NULL,
+    `type` ENUM('retro', 'scrum', 'meeting') NOT NULL,
     `title` VARCHAR(20) NOT NULL,
     `contents` TEXT,
     `created_at` DATETIME NOT NULL,
@@ -189,4 +189,4 @@ CREATE TABLE `meeting_template` (
     `updated_at` DATETIME NOT NULL,
     `deleted_at` DATETIME,
     FOREIGN KEY (`project_id`) REFERENCES `project`(`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci; 
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
+++ b/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
@@ -76,7 +76,8 @@ CREATE TABLE `issue` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
 CREATE TABLE `image` (
-    `profile_id` BIGINT PRIMARY KEY,
+    `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
+    `profile_id` BIGINT NOT NULL,
     `url` TEXT NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NOT NULL,

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserTest.java
@@ -1,0 +1,47 @@
+package scrumpledpaper.agiler.user;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import scrumpledpaper.agiler.user.entity.User;
+import scrumpledpaper.agiler.user.repository.UserRepository;
+
+@SpringBootTest
+public class UserTest {
+	@Autowired
+	private UserRepository userRepository;
+
+	@Test
+	@Transactional
+	void userCanDeleteIssueAndHTableWorksProperly() throws Exception {
+		// given
+		User testUser = new User();
+		setField(testUser, "vendor", "testVendor");
+		setField(testUser, "vendorId", "testVendorId");
+		setField(testUser, "nickname", "testNick");
+		setField(testUser, "imgId", 1L);
+		userRepository.save(testUser);
+
+		// when
+		userRepository.delete(testUser);
+		userRepository.flush();
+
+		// then
+		Optional<User> deletedUser = userRepository.findById(testUser.getId());
+		assertThat(deletedUser).isEmpty();
+	}
+
+
+	private void setField(Object target, String fieldName, Object value) throws Exception {
+		Field field = target.getClass().getDeclaredField(fieldName);
+		field.setAccessible(true);
+		field.set(target, value);
+	}
+}


### PR DESCRIPTION
## 🚀 기능 개요

기존 작성한 API 명세에 맞는 V1 DB를 추가하고, 이를 위한 JPA Entity 클래스와 Repository를 각 도메인별로 작성했습니다.

## 🧩 작업 사항

- V1 DB 테이블 신규 생성용 Flyway 마이그레이션 스크립트 작성

- 도메인별 JPA Entity 클래스 작성

- 각 Entity와 API 명세 기준 필드 매핑 점검 (ddl-auto : validate 옵션으로 실행)

- 각 Entitiy와 매핑되는 Repository 생성

## 🗂️ 이슈 번호

- closed #3 