### PR TITLE
[BE] ✨ 기본 프로필 조회 API 작성

### DIFF
--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -32,13 +32,24 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 	compileOnly 'org.projectlombok:lombok'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.springframework.security:spring-security-test'

--- a/apps/backend/build.gradle
+++ b/apps/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.6'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'java-test-fixtures'
 }
 
 group = 'scrumpledpaper'
@@ -36,9 +37,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
-	compileOnly 'org.projectlombok:lombok'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 
 	// jwt
@@ -48,7 +47,6 @@ dependencies {
 
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
-	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
@@ -56,6 +54,14 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// testFixtures
+	testFixturesImplementation 'org.springframework.boot:spring-boot-starter'
+	testFixturesImplementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	testFixturesImplementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	testFixturesImplementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	testFixturesCompileOnly 'org.projectlombok:lombok'
+	testFixturesAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/AppProperties.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/AppProperties.java
@@ -1,0 +1,25 @@
+package scrumpledpaper.agiler.common.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Component
+@ConfigurationProperties(prefix = "app")
+@Getter
+public class AppProperties {
+
+	private final Auth auth = new Auth();
+
+	@Getter
+	@Setter
+	public static class Auth {
+		private String tokenSecret;
+		private String refreshTokenSecret;
+		private long tokenExpiry;
+		private long refreshTokenExpiry;
+	}
+}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SwaggerConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package scrumpledpaper.agiler.common.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+
+@Configuration
+public class SwaggerConfig {
+	@Bean
+	public GroupedOpenApi RiotDataGroup() {
+		return GroupedOpenApi.builder()
+			.group("Agiler")
+			.pathsToMatch("/**")
+			.packagesToScan("scrumpledpaper.agiler")
+			.build();
+	}
+
+	@Bean
+	public OpenAPI springShopOpenAPI() {
+		return new OpenAPI()
+			.info(new Info()
+				.title("Agiler API")
+				.version("v1.0")
+				.description("Agiler Backend API with JWT Authentication"))
+			.addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+			.components(new io.swagger.v3.oas.models.Components()
+				.addSecuritySchemes("bearerAuth",
+					new SecurityScheme()
+						.type(SecurityScheme.Type.HTTP)
+						.scheme("bearer")
+						.bearerFormat("JWT")
+						.description("Enter your JWT token here")));
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SwaggerConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SwaggerConfig.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 @Configuration
 public class SwaggerConfig {
 	@Bean
-	public GroupedOpenApi RiotDataGroup() {
+	public GroupedOpenApi agilerApiGroup() {
 		return GroupedOpenApi.builder()
 			.group("Agiler")
 			.pathsToMatch("/**")

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/WebConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/WebConfig.java
@@ -1,0 +1,22 @@
+package scrumpledpaper.agiler.common.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.resolver.LoginArgumentResolver;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+	private final LoginArgumentResolver loginArgumentResolver;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginArgumentResolver);
+	}
+}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/CustomException.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package scrumpledpaper.agiler.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
@@ -1,0 +1,21 @@
+package scrumpledpaper.agiler.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+	INVALID_TOKEN(401, "A001", "유효하지 않은 토큰입니다."),
+	EXPIRED_TOKEN(403, "A002", "만료된 토큰입니다."),
+
+	IMAGE_NOT_FOUND(404, "I001", "이미지를 찾을 수 없습니다.");
+
+	private final int status;
+	private final String code;
+	private final String message;
+
+	ErrorCode(int status, String code, String message) {
+		this.status = status;
+		this.code = code;
+		this.message = message;
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorResponse.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorResponse.java
@@ -1,0 +1,16 @@
+package scrumpledpaper.agiler.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+class ErrorResponse {
+	private final String code;
+	private final String message;
+
+	public ErrorResponse(ErrorCode errorCode) {
+		this.code = errorCode.getCode();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/GlobalExceptionHandler.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package scrumpledpaper.agiler.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+		ErrorCode errorCode = ex.getErrorCode();
+		return ResponseEntity
+			.status(errorCode.getStatus())
+			.body(new ErrorResponse(errorCode));
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/resolver/Login.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/resolver/Login.java
@@ -1,0 +1,11 @@
+package scrumpledpaper.agiler.common.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/resolver/LoginArgumentResolver.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/resolver/LoginArgumentResolver.java
@@ -1,0 +1,50 @@
+package scrumpledpaper.agiler.common.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
+import scrumpledpaper.agiler.user.dto.UserDto;
+import scrumpledpaper.agiler.user.entity.User;
+import scrumpledpaper.agiler.user.service.UserService;
+
+@Component
+@RequiredArgsConstructor
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final UserService userService;
+	private final AuthTokenProvider authTokenProvider;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
+		boolean hasUserDtoType = UserDto.class.isAssignableFrom(parameter.getParameterType());
+		return hasLoginAnnotation && hasUserDtoType;
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+		HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+
+		String token = request.getHeader("Authorization");
+		if (token != null && token.startsWith("Bearer ")) {
+			token = token.substring(7);
+			
+			if (!authTokenProvider.validateToken(token)) {
+				throw new RuntimeException("Invalid token");
+			}
+			
+			Long userId = authTokenProvider.getUserIdFromAccessToken(token);
+			User user = userService.findById(userId);
+			return UserDto.from(user);
+		}
+		throw new RuntimeException("No valid token");
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/AuthTokenProvider.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/AuthTokenProvider.java
@@ -1,0 +1,79 @@
+package scrumpledpaper.agiler.common.utils;
+
+import static scrumpledpaper.agiler.common.exception.ErrorCode.*;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import scrumpledpaper.agiler.common.config.AppProperties;
+import scrumpledpaper.agiler.common.exception.CustomException;
+
+@Component
+public class AuthTokenProvider {
+	private final AppProperties appProperties;
+	private final SecretKey key;
+	private final SecretKey refreshKey;
+
+	public AuthTokenProvider(AppProperties appProperties) {
+		this.appProperties = appProperties;
+		this.key = Keys.hmacShaKeyFor(appProperties.getAuth().getTokenSecret().getBytes());
+		this.refreshKey = Keys.hmacShaKeyFor(appProperties.getAuth().getRefreshTokenSecret().getBytes());
+	}
+
+	public String createToken(Long userId) {
+		return buildToken(userId, key, appProperties.getAuth().getTokenExpiry());
+	}
+
+	public String refreshToken(Long userId) {
+		return buildToken(userId, refreshKey, appProperties.getAuth().getRefreshTokenExpiry());
+	}
+
+	private String buildToken(Long userId, SecretKey signingKey, long expiryTime) {
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + expiryTime);
+
+		return Jwts.builder()
+			.subject(userId.toString())
+			.issuedAt(now)
+			.expiration(expiryDate)
+			.signWith(signingKey)
+			.compact();
+	}
+
+	public Long getUserIdFromAccessToken(String accessToken) {
+		Claims claims = getClaims(accessToken, key);
+		return Long.valueOf(claims.getSubject());
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			getClaims(token, key);
+			return true;
+		} catch (CustomException e) {
+			return false;
+		}
+	}
+
+	private Claims getClaims(String token, SecretKey key) {
+		try {
+			return Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+		} catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+			throw new CustomException(INVALID_TOKEN);
+		} catch (ExpiredJwtException e) {
+			throw new CustomException(EXPIRED_TOKEN);
+		}
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
@@ -20,9 +20,6 @@ public class Image extends BaseEntity {
 	@Column(name = "id")
 	private Long id;
 
-	@Column(name = "profile_id")
-	private Long profileId;
-
 	@Column(name = "url", nullable = false)
 	private String url;
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/entity/Image.java
@@ -6,12 +6,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import scrumpledpaper.agiler.common.BaseEntity;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "image")
 public class Image extends BaseEntity {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/service/ImageService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/service/ImageService.java
@@ -1,0 +1,22 @@
+package scrumpledpaper.agiler.image.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.exception.CustomException;
+import scrumpledpaper.agiler.common.exception.ErrorCode;
+import scrumpledpaper.agiler.image.entity.Image;
+import scrumpledpaper.agiler.image.repository.ImageRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ImageService {
+	private final ImageRepository imageRepository;
+
+	public Long findById(Long imageId) {
+		Image image = imageRepository.findById(imageId).orElseThrow(() -> new CustomException(ErrorCode.IMAGE_NOT_FOUND));
+		return image.getId();
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/image/service/ImageService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/image/service/ImageService.java
@@ -19,4 +19,9 @@ public class ImageService {
 		Image image = imageRepository.findById(imageId).orElseThrow(() -> new CustomException(ErrorCode.IMAGE_NOT_FOUND));
 		return image.getId();
 	}
+
+	public String getImageUrl(Long imageId) {
+		Image image = imageRepository.findById(imageId).orElseThrow(() -> new CustomException(ErrorCode.IMAGE_NOT_FOUND));
+		return image.getUrl();
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Issue.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Issue.java
@@ -37,7 +37,7 @@ public class Issue extends BaseEntity {
 	private String title;
 
 	@Column(name = "is_done", nullable = false)
-	private boolean done;
+	private Boolean isDone;
 
 	@Column(name = "contents")
 	private String contents;

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/KanbanConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/KanbanConfig.java
@@ -40,5 +40,5 @@ public class KanbanConfig extends BaseEntity {
 	private boolean backlog;
 
 	@Column(name = "is_done", nullable = false)
-	private boolean done;
+	private Boolean isDone;
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/UserController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/UserController.java
@@ -1,0 +1,36 @@
+package scrumpledpaper.agiler.user.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.resolver.Login;
+import scrumpledpaper.agiler.user.dto.TokenResponseDto;
+import scrumpledpaper.agiler.user.dto.UserDto;
+import scrumpledpaper.agiler.user.dto.UserResDto;
+import scrumpledpaper.agiler.user.service.UserService;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class UserController {
+	private final UserService userService;
+
+	@PostMapping("/login") // todo
+	public ResponseEntity<TokenResponseDto> login(@RequestBody String email) {
+		TokenResponseDto tokenResponseDto = userService.login(email);
+		return ResponseEntity.created(null).body(tokenResponseDto);
+	}
+
+
+	@GetMapping("/users")
+	public ResponseEntity<UserResDto> getUser(@Parameter(hidden = true) @Login UserDto userDto) {
+		UserResDto userResDto = userService.getUser(userDto);
+		return ResponseEntity.ok(userResDto);
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/TokenResponseDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/TokenResponseDto.java
@@ -1,12 +1,4 @@
 package scrumpledpaper.agiler.user.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class TokenResponseDto {
-	private String accessToken;
-	private String refreshToken;
-	private String tokenType;
+public record TokenResponseDto(String accessToken, String refreshToken, String tokenType) {
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/TokenResponseDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/TokenResponseDto.java
@@ -1,0 +1,12 @@
+package scrumpledpaper.agiler.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class TokenResponseDto {
+	private String accessToken;
+	private String refreshToken;
+	private String tokenType;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserDto.java
@@ -1,0 +1,27 @@
+package scrumpledpaper.agiler.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scrumpledpaper.agiler.user.entity.User;
+
+@Getter
+@Builder
+public class UserDto {
+	private Long id;
+	private String vendor;
+	private String vendorId;
+	private String email;
+	private String nickname;
+	private Long imageId;
+
+	public static UserDto from(User user) {
+		return UserDto.builder()
+			.id(user.getId())
+			.vendor(user.getVendor())
+			.vendorId(user.getVendorId())
+			.email(user.getEmail())
+			.nickname(user.getNickname())
+			.imageId(user.getImageId())
+			.build();
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserResDto.java
@@ -1,11 +1,5 @@
 package scrumpledpaper.agiler.user.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class UserResDto {
-	private String nickname;
-	private String imageUrl;
+public record UserResDto(String nickname, String imageUrl) {
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserResDto.java
@@ -1,0 +1,11 @@
+package scrumpledpaper.agiler.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResDto {
+	private String nickname;
+	private String imageUrl;
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
@@ -7,12 +7,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import scrumpledpaper.agiler.common.BaseEntity;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "user")
 public class User extends BaseEntity {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
@@ -1,6 +1,5 @@
 package scrumpledpaper.agiler.user.entity;
 
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -28,7 +27,6 @@ public class User extends BaseEntity {
 	@Column(name = "vendor")
 	private String vendor;
 
-	@Column(name = "vendor_id", nullable = false)
 	@Column(name = "vendor_id")
 	private String vendorId;
 
@@ -38,8 +36,6 @@ public class User extends BaseEntity {
 	@Column(name = "nickname", nullable = false)
 	private String nickname;
 
-	@Column(name = "img_id", nullable = false)
-	private long imgId;
 	@Column(name = "image_id", nullable = false)
 	private long imageId;
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
@@ -25,6 +25,7 @@ public class User extends BaseEntity {
 	private String vendor;
 
 	@Column(name = "vendor_id", nullable = false)
+	@Column(name = "vendor_id")
 	private String vendorId;
 
 	@Column(name = "email")
@@ -35,4 +36,6 @@ public class User extends BaseEntity {
 
 	@Column(name = "img_id", nullable = false)
 	private long imgId;
+	@Column(name = "image_id", nullable = false)
+	private long imageId;
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/mapper/UserMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/mapper/UserMapper.java
@@ -1,0 +1,14 @@
+package scrumpledpaper.agiler.user.mapper;
+
+import org.mapstruct.Mapper;
+
+import scrumpledpaper.agiler.user.dto.UserDto;
+import scrumpledpaper.agiler.user.dto.UserResDto;
+import scrumpledpaper.agiler.user.entity.User;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+	User toEntity(String email, String nickname, Long imageId);
+
+	UserResDto toDto(UserDto userDto, String imageUrl);
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import scrumpledpaper.agiler.user.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+	User findByEmail(String email);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/service/ProfileService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/service/ProfileService.java
@@ -1,0 +1,17 @@
+package scrumpledpaper.agiler.user.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.user.dto.UserResDto;
+import scrumpledpaper.agiler.user.repository.ProfileRepository;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileService {
+	private final ProfileRepository profileRepository;
+
+	public UserResDto getProfile(Long userId) {
+		return null;
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/service/UserService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/service/UserService.java
@@ -1,0 +1,49 @@
+package scrumpledpaper.agiler.user.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
+import scrumpledpaper.agiler.image.service.ImageService;
+import scrumpledpaper.agiler.user.dto.TokenResponseDto;
+import scrumpledpaper.agiler.user.dto.UserDto;
+import scrumpledpaper.agiler.user.dto.UserResDto;
+import scrumpledpaper.agiler.user.entity.User;
+import scrumpledpaper.agiler.user.mapper.UserMapper;
+import scrumpledpaper.agiler.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserService {
+	private final UserMapper userMapper;
+	private final ImageService imageService;
+	private final UserRepository userRepository;
+	private final AuthTokenProvider authTokenProvider;
+
+	public User findById(Long userId) { // todo
+		return userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+	}
+
+	public TokenResponseDto login(String email) { // todo
+		Long imageId = imageService.findById(1L);
+
+		User user = userRepository.findByEmail(email);
+		if (user == null) {
+			user = userMapper.toEntity(email, "nickname", imageId);
+			userRepository.save(user);
+		}
+
+		String accessToken = authTokenProvider.createToken(user.getId());
+		String refreshToken = authTokenProvider.refreshToken(user.getId());
+
+		return new TokenResponseDto(accessToken, refreshToken, "Bearer");
+	}
+
+	public UserResDto getUser(UserDto userDto) {
+		String imageUrl = imageService.getImageUrl(userDto.getImageId());
+		return userMapper.toDto(userDto, imageUrl);
+	}
+}
+

--- a/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
+++ b/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
@@ -4,7 +4,7 @@ CREATE TABLE `user` (
     `vendor_id` VARCHAR(50),
     `email` VARCHAR(40),
     `nickname` VARCHAR(20) NOT NULL,
-    `img_id` BIGINT NOT NULL,
+    `image_id` BIGINT NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NOT NULL,
     `deleted_at` DATETIME
@@ -77,7 +77,6 @@ CREATE TABLE `issue` (
 
 CREATE TABLE `image` (
     `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
-    `profile_id` BIGINT NOT NULL,
     `url` TEXT NOT NULL,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NOT NULL,

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserControllerTest.java
@@ -1,0 +1,93 @@
+package scrumpledpaper.agiler.user;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import scrumpledpaper.agiler.fixture.ImageFixture;
+import scrumpledpaper.agiler.fixture.TokenFixture;
+import scrumpledpaper.agiler.fixture.UserFixture;
+import scrumpledpaper.agiler.image.entity.Image;
+import scrumpledpaper.agiler.image.repository.ImageRepository;
+import scrumpledpaper.agiler.user.dto.UserResDto;
+import scrumpledpaper.agiler.user.entity.User;
+import scrumpledpaper.agiler.user.repository.UserRepository;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class UserControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private TokenFixture tokenFixture;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private ImageRepository imageRepository;
+
+	@Nested
+	@DisplayName("Get User Test")
+	class GetUserTest {
+		@BeforeEach
+		void beforeEach() {
+			Image image = ImageFixture.createImage();
+			imageRepository.save(image);
+		}
+
+		@Test
+		@DisplayName("200 - User Get Success")
+		public void userGetSuccess() throws Exception {
+			// given
+			User user = UserFixture.createUser();
+			userRepository.save(user);
+			String accessToken = tokenFixture.createAccessToken(user);
+			// when
+			String res = mockMvc.perform(
+					get("/api/v1/users")
+						.header("Authorization", "Bearer " + accessToken)
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+			// then
+			UserResDto userResDto = objectMapper.readValue(res, UserResDto.class);
+			assertThat(userResDto.getNickname()).isEqualTo(user.getNickname());
+			Image image = imageRepository.findById(user.getImageId())
+				.orElseThrow();
+			assertThat(userResDto.getImageUrl()).isEqualTo(image.getUrl());
+		}
+
+		@Test
+		@DisplayName("404 - Not Found Image")
+		public void notFoundImage() throws Exception {
+			// given
+			User user = UserFixture.createUser(999L);
+			userRepository.save(user);
+			String accessToken = tokenFixture.createAccessToken(user);
+			// when
+			String res = mockMvc.perform(
+					get("/api/v1/users")
+						.header("Authorization", "Bearer " + accessToken)
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+			// then
+			assertThat(res).contains("I001").contains("이미지를 찾을 수 없습니다");
+		}
+	}
+}

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserControllerTest.java
@@ -66,10 +66,10 @@ public class UserControllerTest {
 				.andReturn().getResponse().getContentAsString();
 			// then
 			UserResDto userResDto = objectMapper.readValue(res, UserResDto.class);
-			assertThat(userResDto.getNickname()).isEqualTo(user.getNickname());
+			assertThat(userResDto.nickname()).isEqualTo(user.getNickname());
 			Image image = imageRepository.findById(user.getImageId())
 				.orElseThrow();
-			assertThat(userResDto.getImageUrl()).isEqualTo(image.getUrl());
+			assertThat(userResDto.imageUrl()).isEqualTo(image.getUrl());
 		}
 
 		@Test

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.*;
 import java.lang.reflect.Field;
 import java.util.Optional;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,34 +16,37 @@ import scrumpledpaper.agiler.user.entity.User;
 import scrumpledpaper.agiler.user.repository.UserRepository;
 
 @SpringBootTest
+@Transactional
 public class UserTest {
 	@Autowired
 	private UserRepository userRepository;
 
-	@Test
-	@Transactional
-	void userCanDeleteIssueAndHTableWorksProperly() throws Exception {
-		// given
-		User testUser = new User();
-		setField(testUser, "vendor", "testVendor");
-		setField(testUser, "vendorId", "testVendorId");
-		setField(testUser, "nickname", "testNick");
-		setField(testUser, "imgId", 1L);
-		userRepository.save(testUser);
+	@Nested
+	@DisplayName("User Entity HTable test")
+	class HTableTest {
+		@Test
+		void userCanDeleteIssueAndHTableWorksProperly() throws Exception {
+			// given
+			User testUser = new User();
+			setField(testUser, "vendor", "testVendor");
+			setField(testUser, "vendorId", "testVendorId");
+			setField(testUser, "nickname", "testNick");
+			setField(testUser, "imgId", 1L);
+			userRepository.save(testUser);
 
-		// when
-		userRepository.delete(testUser);
-		userRepository.flush();
+			// when
+			userRepository.delete(testUser);
+			userRepository.flush();
 
-		// then
-		Optional<User> deletedUser = userRepository.findById(testUser.getId());
-		assertThat(deletedUser).isEmpty();
-	}
+			// then
+			Optional<User> deletedUser = userRepository.findById(testUser.getId());
+			assertThat(deletedUser).isEmpty();
+		}
 
-
-	private void setField(Object target, String fieldName, Object value) throws Exception {
-		Field field = target.getClass().getDeclaredField(fieldName);
-		field.setAccessible(true);
-		field.set(target, value);
+		private void setField(Object target, String fieldName, Object value) throws Exception {
+			Field field = target.getClass().getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		}
 	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserTest.java
@@ -2,7 +2,6 @@ package scrumpledpaper.agiler.user;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.lang.reflect.Field;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import scrumpledpaper.agiler.fixture.UserFixture;
 import scrumpledpaper.agiler.user.entity.User;
 import scrumpledpaper.agiler.user.repository.UserRepository;
 
@@ -25,28 +25,19 @@ public class UserTest {
 	@DisplayName("User Entity HTable test")
 	class HTableTest {
 		@Test
-		void userCanDeleteIssueAndHTableWorksProperly() throws Exception {
+		@DisplayName("200 - User HTable Success")
+		void userCanDeleteIssueAndHTableWorksProperly() {
 			// given
-			User testUser = new User();
-			setField(testUser, "vendor", "testVendor");
-			setField(testUser, "vendorId", "testVendorId");
-			setField(testUser, "nickname", "testNick");
-			setField(testUser, "imgId", 1L);
-			userRepository.save(testUser);
+			User user = UserFixture.createUser();
+			userRepository.save(user);
 
 			// when
-			userRepository.delete(testUser);
+			userRepository.delete(user);
 			userRepository.flush();
 
 			// then
-			Optional<User> deletedUser = userRepository.findById(testUser.getId());
+			Optional<User> deletedUser = userRepository.findById(user.getId());
 			assertThat(deletedUser).isEmpty();
-		}
-
-		private void setField(Object target, String fieldName, Object value) throws Exception {
-			Field field = target.getClass().getDeclaredField(fieldName);
-			field.setAccessible(true);
-			field.set(target, value);
 		}
 	}
 }

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/ImageFixture.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/ImageFixture.java
@@ -1,0 +1,14 @@
+package scrumpledpaper.agiler.fixture;
+
+import org.springframework.stereotype.Component;
+
+import scrumpledpaper.agiler.image.entity.Image;
+
+public class ImageFixture {
+
+	public static Image createImage() {
+		return Image.builder()
+			.url("http://example.com/image.jpg")
+			.build();
+	}
+}

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/TokenFixture.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/TokenFixture.java
@@ -1,0 +1,19 @@
+package scrumpledpaper.agiler.fixture;
+
+import org.springframework.stereotype.Component;
+
+import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
+import scrumpledpaper.agiler.user.entity.User;
+
+@Component
+public class TokenFixture {
+	private final AuthTokenProvider authTokenProvider;
+
+	public TokenFixture(AuthTokenProvider authTokenProvider) {
+		this.authTokenProvider = authTokenProvider;
+	}
+
+	public String createAccessToken(User user) {
+		return authTokenProvider.createToken(user.getId());
+	}
+}

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/UserFixture.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/UserFixture.java
@@ -1,0 +1,22 @@
+package scrumpledpaper.agiler.fixture;
+
+import scrumpledpaper.agiler.user.entity.User;
+
+public class UserFixture {
+
+	public static User createUser() {
+		return User.builder()
+			.email("test@test.com")
+			.nickname("테스트유저")
+			.imageId(1L)
+			.build();
+	}
+
+	public static User createUser(Long imageId) {
+		return User.builder()
+			.email("test@test.com")
+			.nickname("테스트유저")
+			.imageId(imageId)
+			.build();
+	}
+}


### PR DESCRIPTION
## 🚀 기능 개요
User Table의 user default profile 정보를 반환하는 API와 테스트코드를 작성했습니다.
## 🧩 작업 사항
* token에서 user정보를 UserPrincipal이 아닌 ArgumentResolver로 받기 위한 커스텀 어노테이션 작성
* Entity별 Mapstruct를 사용하는 Mapper 작성
* CustomException 하나를 정의하고, 그에 맞게 ErrorCode를 반환하는 방식으로 Exception을 핸들링하게 작성
* 객체별 Fixture를 만들어 재사용하는 방식으로 TestFixture 작성
* Swagger 추가 및 Bearer token 헤더 추가
* User 조회 API 및 테스트 코드 작성
## 🔄 변경 로직
* DB 수정으로 인한 Entity 컬럼 수정 (user, image, kanban_config) 및 sql 수정
* TestFixture, Swagger, Mapstruct, jwt 의존성 추가
## 🗂️ 이슈 번호
-closed #8 