### PR TITLE
[Bug] 🐛 Spring Security 동작 수정

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/JwtAuthenticationFilter.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package scrumpledpaper.agiler.auth.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import scrumpledpaper.agiler.auth.service.CustomUserDetailsService;
 import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
+import scrumpledpaper.agiler.common.utils.CookieUtils;
 
 import java.io.IOException;
 
@@ -24,8 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final AuthTokenProvider authTokenProvider;
 	private final CustomUserDetailsService customUserDetailsService;
 
-	private static final String AUTHORIZATION_HEADER = "Authorization";
-	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String ACCESS_TOKEN = "accessToken";
 
 	@Override
 	protected void doFilterInternal(
@@ -48,12 +49,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-			return bearerToken.substring(BEARER_PREFIX.length());
-		}
-
-		return null;
+		return CookieUtils.getCookie(request, ACCESS_TOKEN)
+				.map(Cookie::getValue)
+				.orElse(null);
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationFailureHandler.java
@@ -21,11 +21,13 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
 	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
+	private static final String LOGIN_PAGE = "/login";
+
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
 		String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
 				.map(Cookie::getValue)
-				.orElse("/");
+				.orElse(LOGIN_PAGE);
 
 		targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
 				.queryParam("error", exception.getLocalizedMessage())

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,6 +1,5 @@
 package scrumpledpaper.agiler.auth.handler;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,18 +9,12 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 import scrumpledpaper.agiler.auth.oauth2.CustomOAuth2User;
 import scrumpledpaper.agiler.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
-import scrumpledpaper.agiler.common.config.AppProperties;
 import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
 import scrumpledpaper.agiler.common.utils.CookieUtils;
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.Optional;
-
-import static scrumpledpaper.agiler.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 @Slf4j
 @Component
@@ -29,9 +22,10 @@ import static scrumpledpaper.agiler.auth.oauth2.HttpCookieOAuth2AuthorizationReq
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 	private final AuthTokenProvider tokenProvider;
-	private final AppProperties appProperties;
 	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 	private final OAuth2AuthenticationFailureHandler failureHandler;
+
+	private static final String REDIRECT_URL = "/dashboard";
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
@@ -54,37 +48,16 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 	@Override
 	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-		Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-				.map(Cookie::getValue);
-
-		if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
-			throw new IllegalArgumentException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication.");
-		}
-
-		String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
 		Long userId = ((CustomOAuth2User) authentication.getPrincipal()).getUserId();
 		String accessToken = tokenProvider.createToken(userId);
 
-		return UriComponentsBuilder.fromUriString(targetUrl)
-				.queryParam("token", accessToken)
-				.build().toUriString();
+		CookieUtils.addCookie(response, "accessToken", accessToken, 24 * 60 * 60);
+		return REDIRECT_URL;
 	}
 
 	private void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
 		super.clearAuthenticationAttributes(request);
 		httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
-	}
-
-	private boolean isAuthorizedRedirectUri(String uri) {
-		URI clientRedirectUri = URI.create(uri);
-
-		return appProperties.getOauth2().getAuthorizedRedirectUris()
-				.stream()
-				.anyMatch(authorizedRedirectUri -> {
-					URI authorizedURI = URI.create(authorizedRedirectUri);
-					return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-							&& authorizedURI.getPort() == clientRedirectUri.getPort();
-				});
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
@@ -36,7 +36,6 @@ public class SecurityConfig {
 			"/swagger-ui/**",
 			/* auth */
 			"/api/v1/auth/**",
-			"/oauth2/**",
 			/* health check */
 			"/actuator/**"
 	};
@@ -58,11 +57,11 @@ public class SecurityConfig {
 				)
 				.oauth2Login(oauth2 -> oauth2
 						.authorizationEndpoint(auth -> auth
-								.baseUri("/oauth2/authorization")
+								.baseUri("/api/oauth2/authorization")
 								.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
 						)
 						.redirectionEndpoint(redirect -> redirect
-								.baseUri("/login/oauth2/code/*")
+								.baseUri("/api/login/oauth2/code/*")
 						)
 						.userInfoEndpoint(userInfo -> userInfo
 								.userService(customOAuth2UserService)

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/CookieUtils.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/CookieUtils.java
@@ -3,6 +3,7 @@ package scrumpledpaper.agiler.common.utils;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
 
 import java.util.Base64;
@@ -24,11 +25,13 @@ public class CookieUtils {
 	}
 
 	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
-		Cookie cookie = new Cookie(name, value);
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
-		cookie.setMaxAge(maxAge);
-		response.addCookie(cookie);
+		ResponseCookie cookie = ResponseCookie.from(name, value)
+				.path("/")
+				.httpOnly(true)
+				.maxAge(maxAge)
+				.sameSite("Lax")
+				.build();
+		response.addHeader("Set-Cookie", cookie.toString());
 	}
 
 	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java
@@ -1,12 +1,14 @@
 package scrumpledpaper.agiler.user.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.utils.CookieUtils;
 import scrumpledpaper.agiler.user.dto.TokenResponseDto;
 import scrumpledpaper.agiler.user.service.UserService;
 
@@ -21,4 +23,11 @@ public class AuthController {
 		TokenResponseDto tokenResponseDto = userService.login(email);
 		return ResponseEntity.created(null).body(tokenResponseDto);
 	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtils.deleteCookie(request, response, "accessToken");
+		return ResponseEntity.noContent().build();
+	}
+
 }


### PR DESCRIPTION
## **🚀 기능 개요**

SecurityConfig에서 **OAuth2 엔드포인트를 /api 접두어로 일원화**하고, 공개 엔드포인트에서 /oauth2/**를 제거해 **API 일관성과 보안성을 향상**했습니다

## **🧩 작업 사항**

- **엔드포인트 경로 변경**
    - Authorization Endpoint Base URI: /oauth2/authorization → **/api/oauth2/authorization**
    - Redirection Endpoint Base URI: /login/oauth2/code/* → **/api/login/oauth2/code/***
- **보안 정책 수정**
    - permitAll 목록에서 **/oauth2/** 제거**

## **🔄 변경 로직**

- 클라이언트는 이제 **/api/oauth2/authorization/{provider}** 로 인가 플로우를 시작합니다.
- OAuth2 프로바이더 콜백(redirect URI)은 **/api/login/oauth2/code/{registrationId}** 경로로 수신됩니다.
    
- 기존 /oauth2/** 경로는 더 이상 공개되지 않으며, 직접 접근 시 401/404가 발생할 수 있습니다.

## **🗂️ 이슈 번호**

- Closed #38 