### PR TITLE
[Bug] 🐛 Spring Security 동작 수정

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/JwtAuthenticationFilter.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package scrumpledpaper.agiler.auth.filter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import scrumpledpaper.agiler.auth.service.CustomUserDetailsService;
 import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
+import scrumpledpaper.agiler.common.utils.CookieUtils;
 
 import java.io.IOException;
 
@@ -24,8 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	private final AuthTokenProvider authTokenProvider;
 	private final CustomUserDetailsService customUserDetailsService;
 
-	private static final String AUTHORIZATION_HEADER = "Authorization";
-	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String ACCESS_TOKEN = "accessToken";
 
 	@Override
 	protected void doFilterInternal(
@@ -48,12 +49,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	}
 
 	private String resolveToken(HttpServletRequest request) {
-		String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-		if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-			return bearerToken.substring(BEARER_PREFIX.length());
-		}
-
-		return null;
+		return CookieUtils.getCookie(request, ACCESS_TOKEN)
+				.map(Cookie::getValue)
+				.orElse(null);
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationFailureHandler.java
@@ -21,11 +21,13 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
 	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
+	private static final String LOGIN_PAGE_URL = "/login";
+
 	@Override
 	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException {
 		String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
 				.map(Cookie::getValue)
-				.orElse("/");
+				.orElse(LOGIN_PAGE_URL);
 
 		targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
 				.queryParam("error", exception.getLocalizedMessage())

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,6 +1,5 @@
 package scrumpledpaper.agiler.auth.handler;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,18 +9,12 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 import scrumpledpaper.agiler.auth.oauth2.CustomOAuth2User;
 import scrumpledpaper.agiler.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
-import scrumpledpaper.agiler.common.config.AppProperties;
 import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
 import scrumpledpaper.agiler.common.utils.CookieUtils;
 
 import java.io.IOException;
-import java.net.URI;
-import java.util.Optional;
-
-import static scrumpledpaper.agiler.auth.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 @Slf4j
 @Component
@@ -29,9 +22,10 @@ import static scrumpledpaper.agiler.auth.oauth2.HttpCookieOAuth2AuthorizationReq
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 	private final AuthTokenProvider tokenProvider;
-	private final AppProperties appProperties;
 	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 	private final OAuth2AuthenticationFailureHandler failureHandler;
+
+	private static final String REDIRECT_URL = "/dashboard";
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
@@ -54,37 +48,16 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
 	@Override
 	protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-		Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-				.map(Cookie::getValue);
-
-		if (redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
-			throw new IllegalArgumentException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication.");
-		}
-
-		String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
 		Long userId = ((CustomOAuth2User) authentication.getPrincipal()).getUserId();
 		String accessToken = tokenProvider.createToken(userId);
 
-		return UriComponentsBuilder.fromUriString(targetUrl)
-				.queryParam("token", accessToken)
-				.build().toUriString();
+		CookieUtils.addCookie(response, "accessToken", accessToken, 24 * 60 * 60);
+		return REDIRECT_URL;
 	}
 
 	private void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
 		super.clearAuthenticationAttributes(request);
 		httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
-	}
-
-	private boolean isAuthorizedRedirectUri(String uri) {
-		URI clientRedirectUri = URI.create(uri);
-
-		return appProperties.getOauth2().getAuthorizedRedirectUris()
-				.stream()
-				.anyMatch(authorizedRedirectUri -> {
-					URI authorizedURI = URI.create(authorizedRedirectUri);
-					return authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
-							&& authorizedURI.getPort() == clientRedirectUri.getPort();
-				});
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
@@ -36,7 +36,6 @@ public class SecurityConfig {
 			"/swagger-ui/**",
 			/* auth */
 			"/api/v1/auth/**",
-			"/oauth2/**",
 			/* health check */
 			"/actuator/**"
 	};
@@ -58,11 +57,11 @@ public class SecurityConfig {
 				)
 				.oauth2Login(oauth2 -> oauth2
 						.authorizationEndpoint(auth -> auth
-								.baseUri("/oauth2/authorization")
+								.baseUri("/api/oauth2/authorization")
 								.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
 						)
 						.redirectionEndpoint(redirect -> redirect
-								.baseUri("/login/oauth2/code/*")
+								.baseUri("/api/login/oauth2/code/*")
 						)
 						.userInfoEndpoint(userInfo -> userInfo
 								.userService(customOAuth2UserService)

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/CookieUtils.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/CookieUtils.java
@@ -3,6 +3,7 @@ package scrumpledpaper.agiler.common.utils;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
 
 import java.util.Base64;
@@ -24,11 +25,13 @@ public class CookieUtils {
 	}
 
 	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
-		Cookie cookie = new Cookie(name, value);
-		cookie.setPath("/");
-		cookie.setHttpOnly(true);
-		cookie.setMaxAge(maxAge);
-		response.addCookie(cookie);
+		ResponseCookie cookie = ResponseCookie.from(name, value)
+				.path("/")
+				.httpOnly(true)
+				.maxAge(maxAge)
+				.sameSite("Lax")
+				.build();
+		response.addHeader("Set-Cookie", cookie.toString());
 	}
 
 	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java
@@ -1,12 +1,14 @@
 package scrumpledpaper.agiler.user.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.utils.CookieUtils;
 import scrumpledpaper.agiler.user.dto.TokenResponseDto;
 import scrumpledpaper.agiler.user.service.UserService;
 
@@ -21,4 +23,11 @@ public class AuthController {
 		TokenResponseDto tokenResponseDto = userService.login(email);
 		return ResponseEntity.created(null).body(tokenResponseDto);
 	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtils.deleteCookie(request, response, "accessToken");
+		return ResponseEntity.noContent().build();
+	}
+
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/SecurityIntegrationTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/SecurityIntegrationTest.java
@@ -1,14 +1,13 @@
 package scrumpledpaper.agiler;
 
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import scrumpledpaper.agiler.annotation.IntegrationTest;
-import scrumpledpaper.agiler.common.AuthContext;
 import scrumpledpaper.agiler.common.TestDataFactory;
-import scrumpledpaper.agiler.common.utils.AuthTokenProvider;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.user.entity.User;
 
@@ -23,9 +22,6 @@ public class SecurityIntegrationTest {
 
     @Autowired
     private TestDataFactory testDataFactory;
-
-    @Autowired
-    private AuthTokenProvider authTokenProvider;
 
     @Test
     @DisplayName("공개 엔드포인트는 인증 없이 접근 가능해야 한다")
@@ -60,14 +56,13 @@ public class SecurityIntegrationTest {
     @DisplayName("보호된 엔드포인트는 유효한 토큰으로 접근 시 200 OK를 반환해야 한다")
     void protectedEndpointShouldReturn200WithValidToken() throws Exception {
         // Given
-        Image defaultImage = testDataFactory.createDefaultImage();
-        AuthContext auth = testDataFactory.createAuth(defaultImage);
-        User user = auth.getUser();
-        String validToken = authTokenProvider.createToken(user.getId());
+		Image image = testDataFactory.createDefaultImage();
+		User user = testDataFactory.createUser(image.getId());
+        String cookie = testDataFactory.createAccessToken(user);
 
         // When & Then
         mockMvc.perform(get("/api/v1/users")
-                        .header("Authorization", "Bearer " + validToken)
+						.cookie(new Cookie("accessToken", cookie))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
     }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/image/S3IntegrationTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/image/S3IntegrationTest.java
@@ -2,6 +2,7 @@ package scrumpledpaper.agiler.image;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,10 +13,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import scrumpledpaper.agiler.annotation.IntegrationTest;
-import scrumpledpaper.agiler.common.AuthContext;
+import scrumpledpaper.agiler.common.TestDataFactory;
 import scrumpledpaper.agiler.fixture.ImageFixture;
-import scrumpledpaper.agiler.fixture.TokenFixture;
-import scrumpledpaper.agiler.fixture.UserFixture;
 import scrumpledpaper.agiler.image.dto.ImageUploadConfirmationRequestDto;
 import scrumpledpaper.agiler.image.dto.ImageUploadConfirmationResponseDto;
 import scrumpledpaper.agiler.image.dto.PreSignedUrlRequestDto;
@@ -23,7 +22,6 @@ import scrumpledpaper.agiler.image.dto.PreSignedUrlResponseDto;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.image.repository.ImageRepository;
 import scrumpledpaper.agiler.user.entity.User;
-import scrumpledpaper.agiler.user.repository.UserRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,27 +37,23 @@ class S3IntegrationTest {
 	@Autowired
 	private ObjectMapper om;
 	@Autowired
-	private UserRepository userRepository;
-	@Autowired
-	private TokenFixture tokenFixture;
+	private TestDataFactory testDataFactory;
 	@Autowired
 	private ImageRepository imageRepository;
-	private String accessToken;
 	@Autowired
 	private AmazonS3 amazonS3Client;
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 	private User user;
+	private String cookie;
 
 	@BeforeEach
 	void setUp() {
-		Image image = ImageFixture.createImage();
-		imageRepository.save(image);
-		User user = UserFixture.createUser(image);
+		Image image = testDataFactory.createDefaultImage();
+		User user = testDataFactory.createUser(image.getId());
 		this.user = user;
-		userRepository.save(user);
-		accessToken = tokenFixture.createAccessToken(user);
-		AuthContext authContext = new AuthContext(user, accessToken);
+		cookie = testDataFactory.createAccessToken(user);
+
 	}
 
 	@ParameterizedTest
@@ -78,7 +72,7 @@ class S3IntegrationTest {
 		String res = mockMvc.perform(
 						post("/api/v1/s3/pre-signed-url")
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("Authorization", "Bearer " + accessToken)
+								.cookie(new Cookie("accessToken", cookie))
 								.content(om.writeValueAsString(req)))
 				.andExpect(status().isOk())
 				.andReturn()
@@ -111,7 +105,7 @@ class S3IntegrationTest {
 		mockMvc.perform(
 						post("/api/v1/s3/pre-signed-url")
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("Authorization", "Bearer " + accessToken)
+								.cookie(new Cookie("accessToken", cookie))
 								.content(om.writeValueAsString(req)))
 				.andExpect(status().isBadRequest());
 	}
@@ -130,7 +124,7 @@ class S3IntegrationTest {
 		String res = mockMvc.perform(
 						post("/api/v1/s3/confirm-upload")
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("Authorization", "Bearer " + accessToken)
+								.cookie(new Cookie("accessToken", cookie))
 								.content(om.writeValueAsString(req)))
 				.andExpect(status().isOk())
 				.andReturn()
@@ -160,7 +154,7 @@ class S3IntegrationTest {
 
 		// when
 		mockMvc.perform(delete("/api/v1/s3/{imageId}", image.getId())
-						.header("Authorization", "Bearer " + accessToken))
+						.cookie(new Cookie("accessToken", cookie)))
 				.andExpect(status().isNoContent());
 
 		// then
@@ -179,7 +173,7 @@ class S3IntegrationTest {
 
 		// when & then
 		mockMvc.perform(delete("/api/v1/s3/{imageId}", nonExistentImageId)
-						.header("Authorization", "Bearer " + accessToken))
+						.cookie(new Cookie("accessToken", cookie)))
 				.andExpect(status().isNotFound());
 	}
 

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/project/ProjectControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/project/ProjectControllerTest.java
@@ -2,6 +2,7 @@ package scrumpledpaper.agiler.project;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -68,12 +69,12 @@ public class ProjectControllerTest {
 			String updateJson = objectMapper.writeValueAsString(createReqDto);
 			// when
 			String response = mockMvc.perform(
-					post("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(updateJson))
-				.andExpect(status().isCreated())
-				.andReturn().getResponse().getContentAsString();
+							post("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(updateJson))
+					.andExpect(status().isCreated())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			ProjectIdResDto projectIdResDto = objectMapper.readValue(response, ProjectIdResDto.class);
 			Project createdProject = testDataFactory.findProjectById(projectIdResDto.id());
@@ -84,8 +85,8 @@ public class ProjectControllerTest {
 			assertThat(createdProject.getSummary()).isEqualTo(createReqDto.summary());
 
 			Profile ownerProfile = testDataFactory.findProfileByUserIdAndProjectId(
-				auth.getUser().getId(),
-				createdProject.getId()
+					auth.getUser().getId(),
+					createdProject.getId()
 			);
 			assertThat(ownerProfile.getRole()).isEqualTo(Role.OWNER);
 			assertThat(ownerProfile.getEmail()).isEqualTo(auth.getUser().getEmail());
@@ -103,12 +104,12 @@ public class ProjectControllerTest {
 			String updateJson = objectMapper.writeValueAsString(createReqDto);
 			// when
 			String response = mockMvc.perform(
-					post("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(updateJson))
-				.andExpect(status().isConflict())
-				.andReturn().getResponse().getContentAsString();
+							post("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(updateJson))
+					.andExpect(status().isConflict())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_URL_ALREADY_EXISTS.getCode());
 		}
@@ -131,12 +132,12 @@ public class ProjectControllerTest {
 			testDataFactory.createProject(url);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/check")
-						.header("Authorization", auth.bearer())
-						.param("url", url)
-				)
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/check")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("url", url)
+					)
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			ProjectCheckResDto projectCheckResDto = objectMapper.readValue(response, ProjectCheckResDto.class);
 			assertThat(projectCheckResDto.isDuplicated()).isTrue();
@@ -150,12 +151,12 @@ public class ProjectControllerTest {
 			String url = "test-url_tag";
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/check")
-						.header("Authorization", auth.bearer())
-						.param("url", url)
-				)
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/check")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("url", url)
+					)
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			ProjectCheckResDto projectCheckResDto = objectMapper.readValue(response, ProjectCheckResDto.class);
 			assertThat(projectCheckResDto.isDuplicated()).isFalse();
@@ -163,16 +164,16 @@ public class ProjectControllerTest {
 
 		@ParameterizedTest
 		@ValueSource(strings = {
-			"test_url_tag",
-			"test__tag",
-			"_tag",
-			"test_",
-			"test",
-			"test#tag",
-			"test tag",
-			"test+tag_name",
-			"",
-			"very-long-project-name-here_very-long-tag-name-here-too"
+				"test_url_tag",
+				"test__tag",
+				"_tag",
+				"test_",
+				"test",
+				"test#tag",
+				"test tag",
+				"test+tag_name",
+				"",
+				"very-long-project-name-here_very-long-tag-name-here-too"
 		})
 		@DisplayName("400 - Invalid Project URL Format")
 		void invalidProjectUrlFormat(String invalidUrl) throws Exception {
@@ -180,10 +181,10 @@ public class ProjectControllerTest {
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			// when & then
 			mockMvc.perform(
-					get("/api/v1/projects/check")
-						.header("Authorization", auth.bearer())
-						.param("url", invalidUrl))
-				.andExpect(status().isBadRequest());
+							get("/api/v1/projects/check")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("url", invalidUrl))
+					.andExpect(status().isBadRequest());
 		}
 	}
 
@@ -203,17 +204,17 @@ public class ProjectControllerTest {
 			testDataFactory.createProjects(auth.getUser(), "project-url", 25);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					});
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(0);
 			assertThat(page.getTotalPages()).isEqualTo(3);
@@ -229,17 +230,17 @@ public class ProjectControllerTest {
 			testDataFactory.createProjects(auth.getUser(), "project-url", 25);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "1")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "1")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					});
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(1);
 			assertThat(page.getTotalPages()).isEqualTo(3);
@@ -255,17 +256,17 @@ public class ProjectControllerTest {
 			testDataFactory.createProjects(auth.getUser(), "project-url", 25);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "2")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "2")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					});
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(2);
 			assertThat(page.getTotalPages()).isEqualTo(3);
@@ -281,16 +282,16 @@ public class ProjectControllerTest {
 			testDataFactory.createProjects(auth.getUser(), "project-url", 25);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "1"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "1"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					});
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(1);
 			assertThat(page.getTotalPages()).isEqualTo(3);
@@ -305,17 +306,17 @@ public class ProjectControllerTest {
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					});
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(0);
 			assertThat(page.getTotalPages()).isEqualTo(0);
@@ -331,12 +332,12 @@ public class ProjectControllerTest {
 			testDataFactory.createProjects(auth.getUser(), "project-url", 25);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "10")
-						.param("size", "10"))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "10")
+									.param("size", "10"))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			assertThat(response).contains(ErrorCode.PAGE_NOT_FOUND.getCode());
 		}
@@ -356,18 +357,18 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(
-				response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				}
+					response,
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					}
 			);
 
 			assertThat(page.getContents()).hasSize(5);
@@ -387,47 +388,47 @@ public class ProjectControllerTest {
 
 			for (int i = 1; i <= 25; i++) {
 				testDataFactory.createProjectWithTime(
-					"project_" + i,
-					auth.getUser(),
-					baseTime.minusHours(25 - i)
+						"project_" + i,
+						auth.getUser(),
+						baseTime.minusHours(25 - i)
 				); // 25가 가장 최신
 			}
 
 			// when
 			PageResDto<ProjectInfoResDto> page1 = objectMapper.readValue(
-				mockMvc.perform(
-						get("/api/v1/projects/info")
-							.header("Authorization", auth.bearer())
-							.param("page", "0")
-							.param("size", "10"))
-					.andExpect(status().isOk())
-					.andReturn().getResponse().getContentAsString(),
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				}
+					mockMvc.perform(
+									get("/api/v1/projects/info")
+											.cookie(new Cookie("accessToken", auth.getToken()))
+											.param("page", "0")
+											.param("size", "10"))
+							.andExpect(status().isOk())
+							.andReturn().getResponse().getContentAsString(),
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					}
 			);
 
 			PageResDto<ProjectInfoResDto> page2 = objectMapper.readValue(
-				mockMvc.perform(
-						get("/api/v1/projects/info")
-							.header("Authorization", auth.bearer())
-							.param("page", "1")
-							.param("size", "10"))
-					.andExpect(status().isOk())
-					.andReturn().getResponse().getContentAsString(),
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				}
+					mockMvc.perform(
+									get("/api/v1/projects/info")
+											.cookie(new Cookie("accessToken", auth.getToken()))
+											.param("page", "1")
+											.param("size", "10"))
+							.andExpect(status().isOk())
+							.andReturn().getResponse().getContentAsString(),
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					}
 			);
 
 			PageResDto<ProjectInfoResDto> page3 = objectMapper.readValue(
-				mockMvc.perform(
-						get("/api/v1/projects/info")
-							.header("Authorization", auth.bearer())
-							.param("page", "2")
-							.param("size", "10"))
-					.andExpect(status().isOk())
-					.andReturn().getResponse().getContentAsString(),
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				}
+					mockMvc.perform(
+									get("/api/v1/projects/info")
+											.cookie(new Cookie("accessToken", auth.getToken()))
+											.param("page", "2")
+											.param("size", "10"))
+							.andExpect(status().isOk())
+							.andReturn().getResponse().getContentAsString(),
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					}
 			);
 
 			// then
@@ -451,11 +452,11 @@ public class ProjectControllerTest {
 			LocalDateTime baseTime = LocalDateTime.now();
 
 			Project project1 = testDataFactory.createProjectWithTime("project_1", owner.getUser(),
-				baseTime.minusDays(10));
+					baseTime.minusDays(10));
 			Project project2 = testDataFactory.createProjectWithTime("project_2", owner.getUser(),
-				baseTime.minusDays(9));
+					baseTime.minusDays(9));
 			Project project3 = testDataFactory.createProjectWithTime("project_3", owner.getUser(),
-				baseTime.minusDays(8));
+					baseTime.minusDays(8));
 
 			AuthContext member = testDataFactory.createAuth(testDataFactory.createDefaultImage());
 
@@ -466,18 +467,18 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", member.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", member.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectInfoResDto> page = objectMapper.readValue(
-				response,
-				new TypeReference<PageResDto<ProjectInfoResDto>>() {
-				}
+					response,
+					new TypeReference<PageResDto<ProjectInfoResDto>>() {
+					}
 			);
 			assertThat(page.getContents().get(0).url()).isEqualTo("project_2");
 			assertThat(page.getContents().get(1).url()).isEqualTo("project_1");
@@ -486,7 +487,7 @@ public class ProjectControllerTest {
 
 		@ParameterizedTest
 		@ValueSource(strings = {
-			"createdAt"
+				"createdAt"
 		})
 		@DisplayName("200 - @Valid 검증 통과")
 		void validatePageReqDto(String sort) throws Exception {
@@ -494,24 +495,24 @@ public class ProjectControllerTest {
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			// when & then
 			mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10")
-						.param("sort", sort))
-				.andExpect(status().isOk());
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10")
+									.param("sort", sort))
+					.andExpect(status().isOk());
 		}
 
 		@ParameterizedTest
 		@ValueSource(strings = {
-			"CREATEDAT",
-			"CreatedAt",
-			"createdat",
-			"createdat",
-			"NonExistingField",
-			"12345",
-			"",
-			"created-at"
+				"CREATEDAT",
+				"CreatedAt",
+				"createdat",
+				"createdat",
+				"NonExistingField",
+				"12345",
+				"",
+				"created-at"
 		})
 		@DisplayName("400 - @Valid 검증 실패")
 		void invalidatePageReqDto(String sort) throws Exception {
@@ -519,13 +520,13 @@ public class ProjectControllerTest {
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/info")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10")
-						.param("sort", sort))
-				.andExpect(status().isBadRequest())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/info")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10")
+									.param("sort", sort))
+					.andExpect(status().isBadRequest())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			assertThat(response).contains(ErrorCode.INVALID_REQUEST.getCode());
 		}
@@ -548,17 +549,17 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					});
 
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(0);
@@ -576,17 +577,17 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "1")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "1")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					});
 
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(1);
@@ -604,17 +605,17 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "2")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "2")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					});
 
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(2);
@@ -632,16 +633,16 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "1"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "1"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					});
 
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(1);
@@ -658,17 +659,17 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				});
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					});
 
 			assertThat(page.getPageSize()).isEqualTo(10);
 			assertThat(page.getCurrentPage()).isEqualTo(0);
@@ -686,12 +687,12 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "3")
-						.param("size", "10"))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "3")
+									.param("size", "10"))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PAGE_NOT_FOUND.getCode());
@@ -712,18 +713,18 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(
-				response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				}
+					response,
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					}
 			);
 
 			assertThat(page.getContents()).hasSize(5);
@@ -743,47 +744,47 @@ public class ProjectControllerTest {
 
 			for (int i = 1; i <= 25; i++) {
 				testDataFactory.createProjectWithTime(
-					"project_" + i,
-					auth.getUser(),
-					baseTime.minusHours(25 - i)
+						"project_" + i,
+						auth.getUser(),
+						baseTime.minusHours(25 - i)
 				); // 25가 가장 최신
 			}
 
 			// when
 			PageResDto<ProjectSideResDto> page1 = objectMapper.readValue(
-				mockMvc.perform(
-						get("/api/v1/projects")
-							.header("Authorization", auth.bearer())
-							.param("page", "0")
-							.param("size", "10"))
-					.andExpect(status().isOk())
-					.andReturn().getResponse().getContentAsString(),
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				}
+					mockMvc.perform(
+									get("/api/v1/projects")
+											.cookie(new Cookie("accessToken", auth.getToken()))
+											.param("page", "0")
+											.param("size", "10"))
+							.andExpect(status().isOk())
+							.andReturn().getResponse().getContentAsString(),
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					}
 			);
 
 			PageResDto<ProjectSideResDto> page2 = objectMapper.readValue(
-				mockMvc.perform(
-						get("/api/v1/projects")
-							.header("Authorization", auth.bearer())
-							.param("page", "1")
-							.param("size", "10"))
-					.andExpect(status().isOk())
-					.andReturn().getResponse().getContentAsString(),
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				}
+					mockMvc.perform(
+									get("/api/v1/projects")
+											.cookie(new Cookie("accessToken", auth.getToken()))
+											.param("page", "1")
+											.param("size", "10"))
+							.andExpect(status().isOk())
+							.andReturn().getResponse().getContentAsString(),
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					}
 			);
 
 			PageResDto<ProjectSideResDto> page3 = objectMapper.readValue(
-				mockMvc.perform(
-						get("/api/v1/projects")
-							.header("Authorization", auth.bearer())
-							.param("page", "2")
-							.param("size", "10"))
-					.andExpect(status().isOk())
-					.andReturn().getResponse().getContentAsString(),
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				}
+					mockMvc.perform(
+									get("/api/v1/projects")
+											.cookie(new Cookie("accessToken", auth.getToken()))
+											.param("page", "2")
+											.param("size", "10"))
+							.andExpect(status().isOk())
+							.andReturn().getResponse().getContentAsString(),
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					}
 			);
 
 			// then
@@ -808,11 +809,11 @@ public class ProjectControllerTest {
 			LocalDateTime baseTime = LocalDateTime.now();
 
 			Project project1 = testDataFactory.createProjectWithTime("project_1", owner.getUser(),
-				baseTime.minusDays(10));
+					baseTime.minusDays(10));
 			Project project2 = testDataFactory.createProjectWithTime("project_2", owner.getUser(),
-				baseTime.minusDays(9));
+					baseTime.minusDays(9));
 			Project project3 = testDataFactory.createProjectWithTime("project_3", owner.getUser(),
-				baseTime.minusDays(8));
+					baseTime.minusDays(8));
 
 			AuthContext member = testDataFactory.createAuth(testDataFactory.createDefaultImage());
 
@@ -823,18 +824,18 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", member.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", member.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProjectSideResDto> page = objectMapper.readValue(
-				response,
-				new TypeReference<PageResDto<ProjectSideResDto>>() {
-				}
+					response,
+					new TypeReference<PageResDto<ProjectSideResDto>>() {
+					}
 			);
 
 			assertThat(page.getContents().get(0).url()).isEqualTo("project_2");
@@ -851,23 +852,23 @@ public class ProjectControllerTest {
 
 			// when & then
 			mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10")
-						.param("sort", sort))
-				.andExpect(status().isOk());
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10")
+									.param("sort", sort))
+					.andExpect(status().isOk());
 		}
 
 		@ParameterizedTest
 		@ValueSource(strings = {
-			"CREATEDAT",
-			"CreatedAt",
-			"createdat",
-			"NonExistingField",
-			"12345",
-			"",
-			"created-at"
+				"CREATEDAT",
+				"CreatedAt",
+				"createdat",
+				"NonExistingField",
+				"12345",
+				"",
+				"created-at"
 		})
 		@DisplayName("400 - @Valid 검증 실패")
 		void invalidatePageReqDto(String sort) throws Exception {
@@ -876,13 +877,13 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects")
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10")
-						.param("sort", sort))
-				.andExpect(status().isBadRequest())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10")
+									.param("sort", sort))
+					.andExpect(status().isBadRequest())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.INVALID_REQUEST.getCode());
@@ -908,11 +909,11 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}", project.getUrl())
-						.header("Authorization", auth.bearer())
-				)
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}", project.getUrl())
+									.cookie(new Cookie("accessToken", auth.getToken()))
+					)
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProjectDetailResDto projectDetailResDto = objectMapper.readValue(response, ProjectDetailResDto.class);
@@ -932,11 +933,11 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}", project.getUrl())
-						.header("Authorization", auth.bearer())
-				)
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}", project.getUrl())
+									.cookie(new Cookie("accessToken", auth.getToken()))
+					)
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProjectDetailResDto projectDetailResDto = objectMapper.readValue(response, ProjectDetailResDto.class);
@@ -954,11 +955,11 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}", nonExistingProjectUrl)
-						.header("Authorization", auth.bearer())
-				)
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}", nonExistingProjectUrl)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+					)
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getCode());
@@ -973,11 +974,11 @@ public class ProjectControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}", project.getUrl())
-						.header("Authorization", auth.bearer())
-				)
-				.andExpect(status().isForbidden())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}", project.getUrl())
+									.cookie(new Cookie("accessToken", auth.getToken()))
+					)
+					.andExpect(status().isForbidden())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getCode());
@@ -1000,20 +1001,20 @@ public class ProjectControllerTest {
 			String url = "test_url";
 			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
 			ProjectUpdateReqDto updateReqDto = new ProjectUpdateReqDto(
-				"새로운 제목",
-				"another_url",
-				"새로운 요약"
+					"새로운 제목",
+					"another_url",
+					"새로운 요약"
 			);
 			String requestBody = objectMapper.writeValueAsString(updateReqDto);
 
 			// when
 			String response = mockMvc.perform(
-					put("/api/v1/projects/{projectUrl}", url)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(requestBody))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							put("/api/v1/projects/{projectUrl}", url)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(requestBody))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProjectIdResDto result = objectMapper.readValue(response, ProjectIdResDto.class);
@@ -1033,20 +1034,20 @@ public class ProjectControllerTest {
 			String url = "test_url";
 			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
 			ProjectUpdateReqDto updateReqDto = new ProjectUpdateReqDto(
-				"새로운 제목",
-				"test_url",
-				"새로운 요약"
+					"새로운 제목",
+					"test_url",
+					"새로운 요약"
 			);
 			String requestBody = objectMapper.writeValueAsString(updateReqDto);
 
 			// when
 			String response = mockMvc.perform(
-					put("/api/v1/projects/{projectUrl}", url)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(requestBody))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							put("/api/v1/projects/{projectUrl}", url)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(requestBody))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProjectIdResDto result = objectMapper.readValue(response, ProjectIdResDto.class);
@@ -1064,19 +1065,19 @@ public class ProjectControllerTest {
 			// given
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			ProjectUpdateReqDto updateReqDto = new ProjectUpdateReqDto(
-				"새로운 제목",
-				"test_url",
-				"새로운 요약"
+					"새로운 제목",
+					"test_url",
+					"새로운 요약"
 			);
 
 			// when
 			String response = mockMvc.perform(
-					put("/api/v1/projects/{projectUrl}", "non-exist_url")
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(updateReqDto)))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							put("/api/v1/projects/{projectUrl}", "non-exist_url")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(objectMapper.writeValueAsString(updateReqDto)))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getCode());
@@ -1091,20 +1092,20 @@ public class ProjectControllerTest {
 			String url = "test_url";
 			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
 			ProjectUpdateReqDto updateReqDto = new ProjectUpdateReqDto(
-				"새로운 제목",
-				"another_url",
-				"새로운 요약"
+					"새로운 제목",
+					"another_url",
+					"새로운 요약"
 			);
 			String requestBody = objectMapper.writeValueAsString(updateReqDto);
 
 			// when & then
 			String response = mockMvc.perform(
-					put("/api/v1/projects/{projectUrl}", url)
-						.header("Authorization", anotherAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(updateReqDto)))
-				.andExpect(status().isForbidden())
-				.andReturn().getResponse().getContentAsString();
+							put("/api/v1/projects/{projectUrl}", url)
+									.cookie(new Cookie("accessToken", anotherAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(objectMapper.writeValueAsString(updateReqDto)))
+					.andExpect(status().isForbidden())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getCode());
@@ -1120,20 +1121,20 @@ public class ProjectControllerTest {
 			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
 			Profile memberProfile = testDataFactory.createProfile(anotherAuth.getUser(), project, Role.MEMBER);
 			ProjectUpdateReqDto updateReqDto = new ProjectUpdateReqDto(
-				"새로운 제목",
-				"another_url",
-				"새로운 요약"
+					"새로운 제목",
+					"another_url",
+					"새로운 요약"
 			);
 			String requestBody = objectMapper.writeValueAsString(updateReqDto);
 
 			// when & then
 			String response = mockMvc.perform(
-					put("/api/v1/projects/{projectUrl}", url)
-						.header("Authorization", anotherAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(objectMapper.writeValueAsString(updateReqDto)))
-				.andExpect(status().isForbidden())
-				.andReturn().getResponse().getContentAsString();
+							put("/api/v1/projects/{projectUrl}", url)
+									.cookie(new Cookie("accessToken", anotherAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(objectMapper.writeValueAsString(updateReqDto)))
+					.andExpect(status().isForbidden())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_OWNER_REQUIRED.getCode());
@@ -1149,20 +1150,20 @@ public class ProjectControllerTest {
 			Project project1 = testDataFactory.createProjectAndOwnerProfile(url1, auth.getUser());
 			Project project2 = testDataFactory.createProjectAndOwnerProfile(url2, auth.getUser());
 			ProjectUpdateReqDto updateReqDto = new ProjectUpdateReqDto(
-				"새로운 제목",
-				url2,
-				"새로운 요약"
+					"새로운 제목",
+					url2,
+					"새로운 요약"
 			);
 			String requestBody = objectMapper.writeValueAsString(updateReqDto);
 
 			// when
 			String response = mockMvc.perform(
-					put("/api/v1/projects/{projectUrl}", url1)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(requestBody))
-				.andExpect(status().isConflict())
-				.andReturn().getResponse().getContentAsString();
+							put("/api/v1/projects/{projectUrl}", url1)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(requestBody))
+					.andExpect(status().isConflict())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_URL_ALREADY_EXISTS.getCode());

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/ProfileControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/ProfileControllerTest.java
@@ -1,9 +1,8 @@
 package scrumpledpaper.agiler.user;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,10 +11,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import scrumpledpaper.agiler.annotation.IntegrationTest;
 import scrumpledpaper.agiler.common.AuthContext;
 import scrumpledpaper.agiler.common.PageResDto;
@@ -26,6 +21,10 @@ import scrumpledpaper.agiler.project.dto.ProfileResDto;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.entity.Role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 @Transactional
@@ -60,17 +59,17 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles", url)
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles", url)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			PageResDto<ProfileResDto> page = objectMapper.readValue(response,
-				new TypeReference<PageResDto<ProfileResDto>>() {
-				});
+					new TypeReference<PageResDto<ProfileResDto>>() {
+					});
 
 			assertThat(page.getTotalElements()).isEqualTo(3);
 			assertThat(page.getContents()).hasSize(3);
@@ -85,12 +84,12 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles", nonExistingUrl)
-						.header("Authorization", auth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles", nonExistingUrl)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getCode());
@@ -107,12 +106,12 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles", url)
-						.header("Authorization", anotherAuth.bearer())
-						.param("page", "0")
-						.param("size", "10"))
-				.andExpect(status().isForbidden())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles", url)
+									.cookie(new Cookie("accessToken", anotherAuth.getToken()))
+									.param("page", "0")
+									.param("size", "10"))
+					.andExpect(status().isForbidden())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getCode());
@@ -128,12 +127,12 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles", url)
-						.header("Authorization", auth.bearer())
-						.param("page", "99")
-						.param("size", "10"))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles", url)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.param("page", "99")
+									.param("size", "10"))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PAGE_NOT_FOUND.getCode());
@@ -159,11 +158,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/me", url)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/me", url)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
@@ -187,11 +186,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/me", url)
-						.header("Authorization", memberAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/me", url)
+									.cookie(new Cookie("accessToken", memberAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
@@ -212,11 +211,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/me", invalidProjectUrl)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/me", invalidProjectUrl)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
@@ -233,11 +232,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/me", url)
-						.header("Authorization", nonMemberAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isForbidden())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/me", url)
+									.cookie(new Cookie("accessToken", nonMemberAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isForbidden())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
@@ -265,11 +264,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, memberProfile.getId())
-						.header("Authorization", ownerAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, memberProfile.getId())
+									.cookie(new Cookie("accessToken", ownerAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
@@ -294,11 +293,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, ownerProfile.getId())
-						.header("Authorization", memberAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, ownerProfile.getId())
+									.cookie(new Cookie("accessToken", memberAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
@@ -319,11 +318,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, myProfile.getId())
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, myProfile.getId())
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
@@ -342,11 +341,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, nonExistentProfileId)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, nonExistentProfileId)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_PROFILE_NOT_FOUND.getMessage());
@@ -362,11 +361,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", invalidUrl, profileId)
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", invalidUrl, profileId)
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
@@ -384,11 +383,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, ownerProfile.getId())
-						.header("Authorization", nonMemberAuth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isForbidden())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url, ownerProfile.getId())
+									.cookie(new Cookie("accessToken", nonMemberAuth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isForbidden())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
@@ -408,11 +407,11 @@ public class ProfileControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url1, profile2.getId())
-						.header("Authorization", auth1.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/projects/{projectUrl}/profiles/{profileId}", url1, profile2.getId())
+									.cookie(new Cookie("accessToken", auth1.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_PROFILE_NOT_FOUND.getMessage());

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/UserControllerTest.java
@@ -1,6 +1,7 @@
 package scrumpledpaper.agiler.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -54,16 +55,16 @@ public class UserControllerTest {
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			// when
 			String res = mockMvc.perform(
-					get("/api/v1/users")
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isOk())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/users")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			UserResDto userResDto = objectMapper.readValue(res, UserResDto.class);
 			assertThat(userResDto.nickname()).isEqualTo(auth.getUser().getNickname());
 			Image image = imageRepository.findById(auth.getUser().getImageId())
-				.orElseThrow();
+					.orElseThrow();
 			assertThat(userResDto.imageUrl()).isEqualTo(image.getUrl());
 		}
 
@@ -75,11 +76,11 @@ public class UserControllerTest {
 			String accessToken = testDataFactory.createAccessToken(user);
 			// when
 			String res = mockMvc.perform(
-					get("/api/v1/users")
-						.header("Authorization", "Bearer " + accessToken)
-						.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isNotFound())
-				.andReturn().getResponse().getContentAsString();
+							get("/api/v1/users")
+									.cookie(new Cookie("accessToken", accessToken))
+									.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isNotFound())
+					.andReturn().getResponse().getContentAsString();
 			// then
 			assertThat(res).contains(ErrorCode.IMAGE_NOT_FOUND.getCode());
 		}
@@ -103,14 +104,14 @@ public class UserControllerTest {
 			String updateJson = objectMapper.writeValueAsString(updateReqDto);
 			// when
 			mockMvc.perform(
-					patch("/api/v1/users")
-						.header("Authorization", auth.bearer())
-						.contentType(MediaType.APPLICATION_JSON)
-						.content(updateJson))
-				.andExpect(status().isNoContent());
+							patch("/api/v1/users")
+									.cookie(new Cookie("accessToken", auth.getToken()))
+									.contentType(MediaType.APPLICATION_JSON)
+									.content(updateJson))
+					.andExpect(status().isNoContent());
 			// then
 			User updatedUser = userRepository.findById(auth.getUser().getId())
-				.orElseThrow();
+					.orElseThrow();
 			assertThat(updatedUser.getNickname()).isEqualTo(updateNickname);
 		}
 

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
@@ -1,27 +1,22 @@
 package scrumpledpaper.agiler.common;
 
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import scrumpledpaper.agiler.fixture.*;
+import scrumpledpaper.agiler.image.entity.Image;
+import scrumpledpaper.agiler.image.repository.ImageRepository;
+import scrumpledpaper.agiler.project.entity.Profile;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.project.entity.Role;
+import scrumpledpaper.agiler.project.repository.ProfileRepository;
+import scrumpledpaper.agiler.project.repository.ProjectRepository;
+import scrumpledpaper.agiler.user.entity.User;
+import scrumpledpaper.agiler.user.repository.UserRepository;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.springframework.stereotype.Component;
-
-import jakarta.persistence.EntityManager;
-import lombok.RequiredArgsConstructor;
-import scrumpledpaper.agiler.fixture.ImageFixture;
-import scrumpledpaper.agiler.fixture.ProfileFixture;
-import scrumpledpaper.agiler.fixture.ProjectFixture;
-import scrumpledpaper.agiler.fixture.TokenFixture;
-import scrumpledpaper.agiler.fixture.UserFixture;
-import scrumpledpaper.agiler.image.entity.Image;
-import scrumpledpaper.agiler.image.repository.ImageRepository;
-import scrumpledpaper.agiler.project.entity.Project;
-import scrumpledpaper.agiler.project.repository.ProjectRepository;
-import scrumpledpaper.agiler.project.entity.Profile;
-import scrumpledpaper.agiler.project.entity.Role;
-import scrumpledpaper.agiler.user.entity.User;
-import scrumpledpaper.agiler.project.repository.ProfileRepository;
-import scrumpledpaper.agiler.user.repository.UserRepository;
 
 @Component
 @RequiredArgsConstructor

--- a/codecov.yml
+++ b/codecov.yml
@@ -30,13 +30,13 @@ flags:
     paths:
       - apps/backend/
     target: 60% # 백엔드 커버리지 목표치를 60%로 설정합니다.
+    ignore:
+      - "src/main/java/scrumpledpaper/agiler/auth/**"
+      - "src/main/java/scrumpledpaper/agiler/common/config/**"
+      - "src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java"
 
 # 커버리지 계산에서 제외할 경로를 지정합니다.
 ignore:
   - "**/node_modules"
   - "apps/backend/build"
-  - "apps/backend/config/S3Config.java"
   - "apps/frontend/dist"
-  - "apps/backend/src/main/java/scrumpledpaper/agiler/auth/**"
-  - "apps/backend/src/main/java/scrumpledpaper/agiler/common/config/**"
-  - "apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java"

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,5 +37,6 @@ ignore:
   - "apps/backend/build"
   - "apps/backend/config/S3Config.java"
   - "apps/frontend/dist"
-  - "apps/backend/src/main/java/scrumpledpaper/agiler/auth"
-
+  - "apps/backend/src/main/java/scrumpledpaper/agiler/auth/**"
+  - "apps/backend/src/main/java/scrumpledpaper/agiler/common/config/**"
+  - "apps/backend/src/main/java/scrumpledpaper/agiler/user/controller/AuthController.java"


### PR DESCRIPTION
## **🚀 기능 개요**

**인증 흐름을 Authorization 헤더 → HTTP-only 쿠키 기반으로 전환**하고, OAuth2 로그인/실패 리다이렉트 및 엔드포인트 경로를 정리했습니다. 이에 맞춰 **통합/컨트롤러 테스트도 쿠키 기반**으로 업데이트했습니다.

## **🧩 작업 사항**

- **JWT/쿠키**
    - JwtAuthenticationFilter가 액세스 토큰을 HTTP-only accessToken **쿠키**에서 읽도록 변경
    - CookieUtils.addCookie가 ResponseCookie를 사용해 HttpOnly, SameSite=Lax 등 보안 속성으로 설정
    - AuthController에 /logout 추가: accessToken 쿠키 삭제로 안전한 로그아웃 지원
- **OAuth2 핸들러**
    - 성공 시 항상 **`/dashboard`** 로 리다이렉트, 토큰은 **쿼리파라미터 대신 보안 쿠키**로 저장
    - 실패 시 기본 리다이렉트를 **`/login`** 으로 통일
- **보안 설정**
    - OAuth2 엔드포인트를 **`/api/oauth2/authorization`**, **`/api/login/oauth2/code/`** 로 네이밍 일원화
- **테스트/유틸**
    - 통합/컨트롤러 테스트 전반을 **Authorization 헤더 → 쿠키 기반**으로 수정(SecurityIntegrationTest, S3IntegrationTest, ProjectControllerTest 등)

## **🔄 변경 로직**

- **인증 플로우**
    1. 로그인 성공 → 서버가 accessToken을 HttpOnly 쿠키로 설정(SameSite=Lax, 필요 시 Secure, Path=/, Max-Age)
    2. 이후 요청에서 필터가 쿠키의 토큰을 검증하여 SecurityContext 구성
    3. 로그아웃 시 /logout 호출 → accessToken 쿠키 삭제
- **OAuth2 플로우**
    - 성공: 토큰 쿠키 설정 후 **/dashboard** 로 리다이렉트
    - 실패: **/login** 으로 리다이렉트
    - 엔드포인트: 인가 시작 /api/oauth2/authorization/{provider} → 콜백 /api/login/oauth2/code/{registrationId}
- **테스트 변경**
    - 인증 필요한 요청은 accessToken **쿠키**를 심어 검증하도록 수정

## 🗂️ 이슈 번호

- Closed #38 