### PR TITLE
[BE] ✨ Project Profile 수정 API

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/controller/ProfileController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/controller/ProfileController.java
@@ -6,6 +6,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +18,7 @@ import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.common.PageReqDto;
 import scrumpledpaper.agiler.common.PageResDto;
 import scrumpledpaper.agiler.project.dto.ProfileResDto;
+import scrumpledpaper.agiler.project.dto.ProfileUpdateReqDto;
 import scrumpledpaper.agiler.project.service.ProjectService;
 
 @RestController
@@ -53,5 +56,15 @@ public class ProfileController {
 		@PathVariable Long profileId) {
 		ProfileResDto profileResDto = projectService.getProjectProfileById(customUserDetails.getUserId(), projectUrl, profileId);
 		return ResponseEntity.ok(profileResDto);
+	}
+
+	@PutMapping("/{projectUrl}/profiles")
+	public ResponseEntity<Void> updateProfile(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@RequestBody @Valid ProfileUpdateReqDto profileUpdateReqDto) {
+		projectService.updateProfile(customUserDetails.getUserId(), projectUrl, profileUpdateReqDto);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/dto/ProfileResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/dto/ProfileResDto.java
@@ -1,7 +1,7 @@
 package scrumpledpaper.agiler.project.dto;
 
 public record ProfileResDto (
-	long memberId,
+	long profileId,
 	String nickname,
 	String email,
 	String imageUrl,

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/dto/ProfileUpdateReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/dto/ProfileUpdateReqDto.java
@@ -1,0 +1,12 @@
+package scrumpledpaper.agiler.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ProfileUpdateReqDto(
+	@NotBlank(message = "닉네임은 비어있을 수 없습니다.")
+	@Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
+	String nickname,
+	String email,
+	String description
+) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/Profile.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/entity/Profile.java
@@ -52,4 +52,10 @@ public class Profile extends BaseEntity {
 
 	@Column(name = "description")
 	private String description;
+
+	public void updateDetails(String nickname, String email, String description) {
+		this.nickname = nickname;
+		this.email = email;
+		this.description = description;
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/mapper/ProfileMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/mapper/ProfileMapper.java
@@ -17,7 +17,7 @@ public interface ProfileMapper {
 	@Mapping(target = "imageId", source = "user.imageId")
 	Profile toEntity(User user, Project project, Role role);
 
-	@Mapping(target = "memberId", source = "profile.id")
+	@Mapping(target = "profileId", source = "profile.id")
 	@Mapping(target = "nickname", source = "profile.nickname")
 	@Mapping(target = "email", source = "profile.email")
 	@Mapping(target = "description", source = "profile.description")

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProfileService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProfileService.java
@@ -11,6 +11,7 @@ import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
 import scrumpledpaper.agiler.project.dto.ProfileResDto;
+import scrumpledpaper.agiler.project.dto.ProfileUpdateReqDto;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.entity.Role;
@@ -77,5 +78,15 @@ public class ProfileService {
 			.orElse("");
 
 		return profileMapper.toProfileResDto(profile, imageUrl);
+	}
+
+	public void updateProfile(long userId, long projectId, ProfileUpdateReqDto profileUpdateReqDto) {
+		Profile profile = getProfileByUserIdAndProjectId(userId, projectId);
+
+		profile.updateDetails(
+			profileUpdateReqDto.nickname(),
+			profileUpdateReqDto.email(),
+			profileUpdateReqDto.description()
+		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProjectService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProjectService.java
@@ -14,6 +14,7 @@ import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
 import scrumpledpaper.agiler.project.dto.ProfileResDto;
+import scrumpledpaper.agiler.project.dto.ProfileUpdateReqDto;
 import scrumpledpaper.agiler.project.dto.ProjectCheckReqDto;
 import scrumpledpaper.agiler.project.dto.ProjectCheckResDto;
 import scrumpledpaper.agiler.project.dto.ProjectCreateReqDto;
@@ -165,5 +166,11 @@ public class ProjectService {
 		validateProjectAccess(userId, project.getId());
 
 		return profileService.getProjectProfileResDto(profileId, project.getId());
+	}
+
+	@Transactional
+	public void updateProfile(long userId, String projectUrl, ProfileUpdateReqDto profileUpdateReqDto) {
+		Project project = findProjectByUrl(projectUrl);
+		profileService.updateProfile(userId, project.getId(), profileUpdateReqDto);
 	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/ProfileControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/ProfileControllerTest.java
@@ -1,8 +1,9 @@
 package scrumpledpaper.agiler.user;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.Cookie;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,6 +12,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.Cookie;
 import scrumpledpaper.agiler.annotation.IntegrationTest;
 import scrumpledpaper.agiler.common.AuthContext;
 import scrumpledpaper.agiler.common.PageResDto;
@@ -18,13 +24,10 @@ import scrumpledpaper.agiler.common.TestDataFactory;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.project.dto.ProfileResDto;
+import scrumpledpaper.agiler.project.dto.ProfileUpdateReqDto;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.entity.Role;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 @Transactional
@@ -166,7 +169,7 @@ public class ProfileControllerTest {
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
-			assertThat(profileResDto.memberId()).isEqualTo(profile.getId());
+			assertThat(profileResDto.profileId()).isEqualTo(profile.getId());
 			assertThat(profileResDto.nickname()).isEqualTo(profile.getNickname());
 			assertThat(profileResDto.imageUrl()).isEqualTo(defaultImage.getUrl());
 			assertThat(profileResDto.role()).isEqualTo(profile.getRole().name());
@@ -194,7 +197,7 @@ public class ProfileControllerTest {
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
-			assertThat(profileResDto.memberId()).isEqualTo(profile.getId());
+			assertThat(profileResDto.profileId()).isEqualTo(profile.getId());
 			assertThat(profileResDto.nickname()).isEqualTo(profile.getNickname());
 			assertThat(profileResDto.imageUrl()).isEqualTo(defaultImage.getUrl());
 			assertThat(profileResDto.role()).isEqualTo(profile.getRole().name());
@@ -272,7 +275,7 @@ public class ProfileControllerTest {
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
-			assertThat(profileResDto.memberId()).isEqualTo(memberProfile.getId());
+			assertThat(profileResDto.profileId()).isEqualTo(memberProfile.getId());
 			assertThat(profileResDto.nickname()).isEqualTo(memberProfile.getNickname());
 			assertThat(profileResDto.imageUrl()).isEqualTo(defaultImage.getUrl());
 			assertThat(profileResDto.role()).isEqualTo(Role.MEMBER.name());
@@ -301,7 +304,7 @@ public class ProfileControllerTest {
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
-			assertThat(profileResDto.memberId()).isEqualTo(ownerProfile.getId());
+			assertThat(profileResDto.profileId()).isEqualTo(ownerProfile.getId());
 			assertThat(profileResDto.nickname()).isEqualTo(ownerProfile.getNickname());
 			assertThat(profileResDto.role()).isEqualTo(Role.OWNER.name());
 			assertThat(profileResDto.email()).isEqualTo(ownerAuth.getUser().getEmail());
@@ -326,7 +329,7 @@ public class ProfileControllerTest {
 
 			// then
 			ProfileResDto profileResDto = objectMapper.readValue(response, ProfileResDto.class);
-			assertThat(profileResDto.memberId()).isEqualTo(myProfile.getId());
+			assertThat(profileResDto.profileId()).isEqualTo(myProfile.getId());
 			assertThat(profileResDto.email()).isEqualTo(auth.getUser().getEmail());
 		}
 

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/user/ProfileControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/user/ProfileControllerTest.java
@@ -420,6 +420,127 @@ public class ProfileControllerTest {
 			assertThat(response).contains(ErrorCode.PROJECT_PROFILE_NOT_FOUND.getMessage());
 		}
 	}
+
+	@Nested
+	@DisplayName("Update Project Profile Test")
+	class UpdateProjectProfileTest {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("204 - 프로젝트 프로필 수정 성공")
+		public void updateProjectProfileSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			ProfileUpdateReqDto updateReqDto = new ProfileUpdateReqDto(
+				"NewNickname",
+				"newEmail@example.com",
+				"New description");
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/profiles", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNoContent())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			Profile updatedProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
+			assertThat(updatedProfile.getNickname()).isEqualTo(updateReqDto.nickname());
+			assertThat(updatedProfile.getEmail()).isEqualTo(updateReqDto.email());
+			assertThat(updatedProfile.getDescription()).isEqualTo(updateReqDto.description());
+		}
+
+		@Test
+		@DisplayName("204 - 기존 값과 같은 값일때 프로필 수정 성공")
+		public void updateProjectProfileWithSameValuesSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile profile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
+			ProfileUpdateReqDto updateReqDto = new ProfileUpdateReqDto(
+				profile.getNickname(),
+				profile.getEmail(),
+				profile.getDescription()
+			);
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/profiles", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNoContent())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			Profile updatedProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
+			assertThat(updatedProfile.getNickname()).isEqualTo(updateReqDto.nickname());
+			assertThat(updatedProfile.getEmail()).isEqualTo(updateReqDto.email());
+			assertThat(updatedProfile.getDescription()).isEqualTo(updateReqDto.description());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트")
+		public void updateProfileProjectNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String invalidUrl = "invalid_url";
+			ProfileUpdateReqDto updateReqDto = new ProfileUpdateReqDto(
+				"NewNickname",
+				"newEmail@example.com",
+				"New description");
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/profiles", invalidUrl)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("403 - 프로젝트 멤버가 아닌 사용자가 프로필 수정 시도")
+		public void updateProfileNotMember() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext nonMemberAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			ProfileUpdateReqDto updateReqDto = new ProfileUpdateReqDto(
+				"NewNickname",
+				"newEmail@example.com",
+				"New description");
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/profiles", url)
+						.cookie(new Cookie("accessToken", nonMemberAuth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+	}
 }
 
 


### PR DESCRIPTION
## 🚀 기능 개요

자신의 Project Profile을 수정하는 API를 구현했습니다.

## 🧩 작업 사항

- Project Profile 수정 API 구현
- Project Profile 수정 API 테스트 코드 작성 

## 🔄 변경 로직

- ProfileResDto의 memberId -> profileId로 수정했습니다.

## 🗂️ 이슈 번호

-closed #44 