### PR TITLE
[BE] ✨ Issue Template 삭제 API

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/IssueTemplateController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/IssueTemplateController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.template.dto.IssueTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.IssueTemplateDeleteReqDto;
 import scrumpledpaper.agiler.template.dto.IssueTemplateDetailResDto;
 import scrumpledpaper.agiler.template.dto.IssueTemplateListResDto;
 import scrumpledpaper.agiler.template.dto.IssueTemplateResDto;
@@ -67,5 +69,15 @@ public class IssueTemplateController {
 		@PathVariable Long templateId) {
 		IssueTemplateDetailResDto template = issueTemplateService.getIssueTemplate(customUserDetails.getUserId(), projectUrl, templateId);
 		return ResponseEntity.ok(template);
+	}
+
+	@DeleteMapping("/{projectUrl}/issues/templates")
+	public ResponseEntity<Void> deleteTemplate(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@RequestBody IssueTemplateDeleteReqDto issueTemplateDeleteReqDto) {
+		issueTemplateService.deleteIssueTemplate(customUserDetails.getUserId(), projectUrl, issueTemplateDeleteReqDto.templateId());
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/IssueTemplateDeleteReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/IssueTemplateDeleteReqDto.java
@@ -1,0 +1,8 @@
+package scrumpledpaper.agiler.template.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record IssueTemplateDeleteReqDto(
+	@NotNull
+	long templateId
+) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/IssueTemplateResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/IssueTemplateResDto.java
@@ -1,7 +1,7 @@
 package scrumpledpaper.agiler.template.dto;
 
 public record IssueTemplateResDto(
-	long id,
+	long templateId,
 	String title,
 	String description
 ) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/IssueTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/IssueTemplateService.java
@@ -79,4 +79,11 @@ public class IssueTemplateService {
 		IssueTemplate issueTemplate = findById(templateId);
 		return issueTemplateMapper.toDetailDto(issueTemplate);
 	}
+
+	public void deleteIssueTemplate(long userId, String projectUrl, Long templateId) {
+		projectValidator.validateAccess(userId, projectUrl);
+
+		IssueTemplate issueTemplate = findById(templateId);
+		issueTemplateRepository.delete(issueTemplate);
+	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/IssueTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/IssueTemplateControllerTest.java
@@ -451,7 +451,7 @@ public class IssueTemplateControllerTest {
 
 			// when
 			mockMvc.perform(
-					delete("/api/v1/projects/{projectUrl}/issues/templates/{templateId}", url, template.getId())
+					delete("/api/v1/projects/{projectUrl}/issues/templates", url)
 						.cookie(new Cookie("accessToken", auth.getToken()))
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(deleteJson))
@@ -482,7 +482,7 @@ public class IssueTemplateControllerTest {
 
 			// when
 			String response = mockMvc.perform(
-					delete("/api/v1/projects/{projectUrl}/issues/templates/{templateId}", url, template.getId())
+					delete("/api/v1/projects/{projectUrl}/issues/templates", url)
 						.cookie(new Cookie("accessToken", ownerAuth.getToken()))
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(deleteJson))

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/IssueTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/IssueTemplateControllerTest.java
@@ -25,6 +25,7 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.dto.IssueTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.IssueTemplateDeleteReqDto;
 import scrumpledpaper.agiler.template.dto.IssueTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.entity.IssueTemplate;
 
@@ -416,6 +417,104 @@ public class IssueTemplateControllerTest {
 					get("/api/v1/projects/{projectUrl}/issues/templates/{templateId}", url, 9999L)
 						.cookie(new Cookie("accessToken", auth.getToken()))
 						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_TEMPLATE_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("delete issue template")
+	class DeleteIssueTemplate {
+		@BeforeEach
+		void setUp() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("204 - 이슈 생성 템플릿 삭제 성공")
+		public void deleteIssueTemplateSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			IssueTemplate template = testDataFactory.createIssueTemplate(
+				project,
+				"버그",
+				"버그 이슈 템플릿",
+				"Template Detail"
+			);
+			IssueTemplateDeleteReqDto deleteReqDto = new IssueTemplateDeleteReqDto(template.getId());
+			String deleteJson = objectMapper.writeValueAsString(deleteReqDto);
+
+			// when
+			mockMvc.perform(
+					delete("/api/v1/projects/{projectUrl}/issues/templates/{templateId}", url, template.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(deleteJson))
+				.andExpect(status().isNoContent())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThatThrownBy(() -> testDataFactory.findIssueTemplateById(template.getId()))
+				.isInstanceOf(Exception.class);
+		}
+
+		@Test
+		@DisplayName("403 - 멤버가 아닌 사용자가 이슈 생성 템플릿 삭제 시도")
+		public void deleteIssueTemplateForbidden() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			IssueTemplate template = testDataFactory.createIssueTemplate(
+				project,
+				"버그",
+				"버그 이슈 템플릿",
+				"Template Detail"
+			);
+			IssueTemplateDeleteReqDto deleteReqDto = new IssueTemplateDeleteReqDto(template.getId());
+			String deleteJson = objectMapper.writeValueAsString(deleteReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					delete("/api/v1/projects/{projectUrl}/issues/templates/{templateId}", url, template.getId())
+						.cookie(new Cookie("accessToken", ownerAuth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(deleteJson))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 이슈 템플릿 삭제 시도")
+		public void deleteIssueTemplateNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			testDataFactory.createIssueTemplate(
+				project,
+				"버그",
+				"버그 이슈 템플릿",
+				"Template Detail"
+			);
+			IssueTemplateDeleteReqDto deleteReqDto = new IssueTemplateDeleteReqDto(9999L);
+			String deleteJson = objectMapper.writeValueAsString(deleteReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					delete("/api/v1/projects/{projectUrl}/issues/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(deleteJson))
 				.andExpect(status().isNotFound())
 				.andReturn().getResponse().getContentAsString();
 


### PR DESCRIPTION
## 🚀 기능 개요

Issue Template를 Soft Delete하는 API를 작성했습니다.

## 🧩 작업 사항

- Issue Template Delete API 작성
- Issue Template Delete API 테스트 코드 작성

## 🔄 변경 로직

- IssueTemplateResDto의 id -> templateId로 변경

## 🗂️ 이슈 번호

- closed #69 
