### PR TITLE
[BE] ✨ Meeting Template 관련 API

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
 
 	ISSUE_TEMPLATE_NOT_FOUND(404, "T001", "이슈 템플릿을 찾을 수 없습니다."),
 	SCRUM_TEMPLATE_NOT_FOUND(404, "T002", "스크럼 템플릿을 찾을 수 없습니다."),
-	RETRO_TEMPLATE_NOT_FOUND(404, "T003", "회고 템플릿을 찾을 수 없습니다.");
+	RETRO_TEMPLATE_NOT_FOUND(404, "T003", "회고 템플릿을 찾을 수 없습니다."),
+	MEETING_TEMPLATE_NOT_FOUND(404, "T004", "회의 템플릿을 찾을 수 없습니다.");
 
 	private final int status;
 	private final String code;

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProjectService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProjectService.java
@@ -29,6 +29,7 @@ import scrumpledpaper.agiler.project.entity.Role;
 import scrumpledpaper.agiler.project.mapper.ProjectMapper;
 import scrumpledpaper.agiler.project.repository.ProjectRepository;
 import scrumpledpaper.agiler.template.service.IssueTemplateService;
+import scrumpledpaper.agiler.template.service.MeetingTemplateService;
 import scrumpledpaper.agiler.template.service.RetroTemplateService;
 import scrumpledpaper.agiler.template.service.ScrumTemplateService;
 import scrumpledpaper.agiler.user.entity.User;
@@ -43,6 +44,7 @@ public class ProjectService {
 	private final LabelService labelService;
 	private final ProfileService profileService;
 	private final IssueTemplateService issueTemplateService;
+	private final MeetingTemplateService meetingTemplateService;
 	private final RetroTemplateService retroTemplateService;
 	private final ScrumTemplateService scrumTemplateService;
 	private final ProjectRepository projectRepository;
@@ -63,6 +65,7 @@ public class ProjectService {
 		labelService.createDefaultLabels(savedProject);
 		issueTemplateService.createDefaultIssueTemplates(savedProject);
 		scrumTemplateService.createDefaultScrumTemplates(savedProject);
+		meetingTemplateService.createDefaultMeetingTemplates(savedProject);
 		retroTemplateService.createDefaultRetroTemplates(savedProject);
 		return projectMapper.toDto(savedProject);
 	}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
@@ -1,0 +1,34 @@
+package scrumpledpaper.agiler.template.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.auth.service.CustomUserDetails;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.service.MeetingTemplateService;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@RequiredArgsConstructor
+public class MeetingTemplateController {
+	private final MeetingTemplateService meetingTemplateService;
+
+	@PostMapping("/{projectUrl}/meetings/templates")
+	public ResponseEntity<Void> createMeetingTemplate(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@RequestBody @Valid MeetingTemplateCreateReqDto meetingTemplateCreateReqDto) {
+		meetingTemplateService.createMeetingTemplate(customUserDetails.getUserId(), projectUrl, meetingTemplateCreateReqDto);
+		return ResponseEntity.noContent().build();
+	}
+
+}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateDeleteReqDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateDetailResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateListResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateResDto;
@@ -70,5 +71,14 @@ public class MeetingTemplateController {
 		return ResponseEntity.ok(template);
 	}
 
+	@DeleteMapping("/{projectUrl}/meetings/templates")
+	public ResponseEntity<Void> deleteMeetingTemplate(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@RequestBody MeetingTemplateDeleteReqDto meetingTemplateDeleteReqDto) {
+		meetingTemplateService.deleteMeetingTemplate(customUserDetails.getUserId(), projectUrl, meetingTemplateDeleteReqDto.templateId());
+		return ResponseEntity.noContent().build();
+	}
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
@@ -1,7 +1,11 @@
 package scrumpledpaper.agiler.template.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -14,6 +18,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateListResDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.service.MeetingTemplateService;
 
@@ -41,6 +47,15 @@ public class MeetingTemplateController {
 		@RequestBody @Valid MeetingTemplateUpdateReqDto meetingTemplateUpdateReqDto) {
 		meetingTemplateService.updateMeetingTemplate(customUserDetails.getUserId(), projectUrl, meetingTemplateUpdateReqDto);
 		return ResponseEntity.noContent().build();
+	}
+
+	public ResponseEntity<MeetingTemplateListResDto> getMeetingTemplates(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl) {
+		List<MeetingTemplateResDto> templates = meetingTemplateService.getMeetingTemplateList(customUserDetails.getUserId(), projectUrl);
+		MeetingTemplateListResDto meetingTemplateListResDto = new MeetingTemplateListResDto(templates, templates.size());
+		return ResponseEntity.ok(meetingTemplateListResDto);
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateDetailResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateListResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
@@ -49,6 +50,7 @@ public class MeetingTemplateController {
 		return ResponseEntity.noContent().build();
 	}
 
+	@GetMapping("/{projectUrl}/meetings/templates")
 	public ResponseEntity<MeetingTemplateListResDto> getMeetingTemplates(
 		@Parameter(hidden = true)
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -56,6 +58,16 @@ public class MeetingTemplateController {
 		List<MeetingTemplateResDto> templates = meetingTemplateService.getMeetingTemplateList(customUserDetails.getUserId(), projectUrl);
 		MeetingTemplateListResDto meetingTemplateListResDto = new MeetingTemplateListResDto(templates, templates.size());
 		return ResponseEntity.ok(meetingTemplateListResDto);
+	}
+
+	@GetMapping("/{projectUrl}/meetings/templates/{templateId}")
+	public ResponseEntity<MeetingTemplateDetailResDto> getMeetingTemplate(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable Long templateId) {
+		MeetingTemplateDetailResDto template = meetingTemplateService.getMeetingTemplate(customUserDetails.getUserId(), projectUrl, templateId);
+		return ResponseEntity.ok(template);
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/controller/MeetingTemplateController.java
@@ -2,7 +2,9 @@ package scrumpledpaper.agiler.template.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.service.MeetingTemplateService;
 
 @RestController
@@ -27,6 +30,16 @@ public class MeetingTemplateController {
 		@PathVariable String projectUrl,
 		@RequestBody @Valid MeetingTemplateCreateReqDto meetingTemplateCreateReqDto) {
 		meetingTemplateService.createMeetingTemplate(customUserDetails.getUserId(), projectUrl, meetingTemplateCreateReqDto);
+		return ResponseEntity.noContent().build();
+	}
+
+	@PutMapping("/{projectUrl}/meetings/templates")
+	public ResponseEntity<Void> updateMeetingTemplate(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@RequestBody @Valid MeetingTemplateUpdateReqDto meetingTemplateUpdateReqDto) {
+		meetingTemplateService.updateMeetingTemplate(customUserDetails.getUserId(), projectUrl, meetingTemplateUpdateReqDto);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateCreateReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateCreateReqDto.java
@@ -1,0 +1,16 @@
+package scrumpledpaper.agiler.template.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MeetingTemplateCreateReqDto(
+	@NotBlank(message = "템플릿 제목은 필수입니다.")
+	@Size(max = 20, message = "템플릿 제목은 20자 이하여야 합니다.")
+	String title,
+
+	@Size(max = 100, message = "설명은 100자 이하여야 합니다.")
+	String description,
+
+	String contents
+) {}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateDeleteReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateDeleteReqDto.java
@@ -1,0 +1,9 @@
+package scrumpledpaper.agiler.template.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MeetingTemplateDeleteReqDto(
+	@NotNull
+	long templateId
+) {}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateDetailResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateDetailResDto.java
@@ -1,0 +1,8 @@
+package scrumpledpaper.agiler.template.dto;
+
+public record MeetingTemplateDetailResDto(
+	String title,
+	String description,
+	String contents
+) {}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateListResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateListResDto.java
@@ -1,0 +1,9 @@
+package scrumpledpaper.agiler.template.dto;
+
+import java.util.List;
+
+public record MeetingTemplateListResDto(
+	List<MeetingTemplateResDto> meetingTemplates,
+	int size
+) {}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/dto/MeetingTemplateResDto.java
@@ -1,0 +1,8 @@
+package scrumpledpaper.agiler.template.dto;
+
+public record MeetingTemplateResDto(
+	long templateId,
+	String title,
+	String description
+) {}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/DefaultMeetingTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/DefaultMeetingTemplate.java
@@ -1,0 +1,29 @@
+package scrumpledpaper.agiler.template.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DefaultMeetingTemplate {
+	TEAM_MEETING(
+		"👥 팀 회의",
+		"팀 회의 템플릿입니다.",
+		"""
+		## 회의 안건
+		1.\s
+
+		
+		## 회의 결과
+		-\s
+
+		
+		## 액션 아이템
+		- [ ]\s
+		"""
+	);
+	private final String title;
+	private final String description;
+	private final String contents;
+}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/MeetingTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/MeetingTemplate.java
@@ -39,4 +39,10 @@ public class MeetingTemplate extends BaseEntity {
 
 	@Column(name = "contents")
 	private String contents;
+
+	public void update(String title, String description, String contents) {
+		this.title = title;
+		this.description = description;
+		this.contents = contents;
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/MeetingTemplate.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/entity/MeetingTemplate.java
@@ -8,13 +8,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.common.BaseEntity;
+import scrumpledpaper.agiler.project.entity.Project;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
 @Table(name = "meeting_template")
 public class MeetingTemplate extends BaseEntity {
@@ -29,6 +33,9 @@ public class MeetingTemplate extends BaseEntity {
 
 	@Column(name = "title", nullable = false)
 	private String title;
+
+	@Column(name = "description")
+	private String description;
 
 	@Column(name = "contents")
 	private String contents;

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
@@ -1,0 +1,19 @@
+package scrumpledpaper.agiler.template.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
+
+@Mapper(componentModel = "spring")
+public interface MeetingTemplateMapper {
+	@Mapping(target = "id", ignore = true)
+	@Mapping(target = "title", source = "defaultMeetingTemplate.title")
+	@Mapping(target = "description", source = "defaultMeetingTemplate.description")
+	@Mapping(target = "contents", source = "defaultMeetingTemplate.contents")
+	MeetingTemplate toEntity(Project project, DefaultMeetingTemplate defaultMeetingTemplate);
+
+}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
 import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 
@@ -14,6 +15,12 @@ public interface MeetingTemplateMapper {
 	@Mapping(target = "description", source = "defaultMeetingTemplate.description")
 	@Mapping(target = "contents", source = "defaultMeetingTemplate.contents")
 	MeetingTemplate toEntity(Project project, DefaultMeetingTemplate defaultMeetingTemplate);
+
+	@Mapping(target = "id", ignore = true)
+	@Mapping(target = "title", source = "meetingTemplateCreateReqDto.title")
+	@Mapping(target = "description", source = "meetingTemplateCreateReqDto.description")
+	@Mapping(target = "contents", source = "meetingTemplateCreateReqDto.contents")
+	MeetingTemplate toEntity(Project project, MeetingTemplateCreateReqDto meetingTemplateCreateReqDto);
 
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
@@ -22,5 +22,8 @@ public interface MeetingTemplateMapper {
 	@Mapping(target = "contents", source = "meetingTemplateCreateReqDto.contents")
 	MeetingTemplate toEntity(Project project, MeetingTemplateCreateReqDto meetingTemplateCreateReqDto);
 
+	@Mapping(target = "templateId", source = "id")
+	MeetingTemplateResDto toDto(MeetingTemplate meetingTemplate);
+
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/mapper/MeetingTemplateMapper.java
@@ -5,6 +5,8 @@ import org.mapstruct.Mapping;
 
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateDetailResDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateResDto;
 import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 
@@ -25,5 +27,6 @@ public interface MeetingTemplateMapper {
 	@Mapping(target = "templateId", source = "id")
 	MeetingTemplateResDto toDto(MeetingTemplate meetingTemplate);
 
+	MeetingTemplateDetailResDto toDetailDto(MeetingTemplate meetingTemplate);
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/MeetingTemplateRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/repository/MeetingTemplateRepository.java
@@ -1,7 +1,10 @@
 package scrumpledpaper.agiler.template.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 
 public interface MeetingTemplateRepository extends JpaRepository<MeetingTemplate, Long> {
+	List<MeetingTemplate> findByProjectId(Long projectId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
@@ -1,0 +1,26 @@
+package scrumpledpaper.agiler.template.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
+import scrumpledpaper.agiler.template.mapper.MeetingTemplateMapper;
+import scrumpledpaper.agiler.template.repository.MeetingTemplateRepository;
+@Service
+@RequiredArgsConstructor
+public class MeetingTemplateService {
+	private final MeetingTemplateMapper meetingTemplateMapper;
+	private final MeetingTemplateRepository meetingTemplateRepository;
+
+	public void createDefaultMeetingTemplates(Project project) {
+		meetingTemplateRepository.saveAll(
+			Arrays.stream(DefaultMeetingTemplate.values())
+				.map(defaultMeetingTemplate -> meetingTemplateMapper.toEntity(project, defaultMeetingTemplate))
+				.toList()
+		);
+	}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
@@ -6,21 +6,35 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.project.service.ProjectValidator;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
 import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 import scrumpledpaper.agiler.template.mapper.MeetingTemplateMapper;
 import scrumpledpaper.agiler.template.repository.MeetingTemplateRepository;
+
 @Service
 @RequiredArgsConstructor
 public class MeetingTemplateService {
 	private final MeetingTemplateMapper meetingTemplateMapper;
 	private final MeetingTemplateRepository meetingTemplateRepository;
+	private final ProjectValidator projectValidator;
 
 	public void createDefaultMeetingTemplates(Project project) {
 		meetingTemplateRepository.saveAll(
 			Arrays.stream(DefaultMeetingTemplate.values())
 				.map(defaultMeetingTemplate -> meetingTemplateMapper.toEntity(project, defaultMeetingTemplate))
 				.toList()
+		);
+	}
+
+	@Transactional
+	public void createMeetingTemplate(long userId, String projectUrl, MeetingTemplateCreateReqDto meetingTemplateCreateReqDto) {
+		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
+		Project project = context.project();
+
+		meetingTemplateRepository.save(
+			meetingTemplateMapper.toEntity(project, meetingTemplateCreateReqDto)
 		);
 	}
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
@@ -4,10 +4,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.exception.CustomException;
+import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.service.ProjectValidator;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 import scrumpledpaper.agiler.template.mapper.MeetingTemplateMapper;
@@ -37,4 +40,18 @@ public class MeetingTemplateService {
 			meetingTemplateMapper.toEntity(project, meetingTemplateCreateReqDto)
 		);
 	}
+
+	@Transactional
+	public void updateMeetingTemplate(long userId, String projectUrl, MeetingTemplateUpdateReqDto meetingTemplateUpdateReqDto) {
+		projectValidator.validateAccess(userId, projectUrl);
+
+		MeetingTemplate meetingTemplate = findById(meetingTemplateUpdateReqDto.templateId());
+		meetingTemplate.update(
+			meetingTemplateUpdateReqDto.title(),
+			meetingTemplateUpdateReqDto.description(),
+			meetingTemplateUpdateReqDto.contents()
+		);
+	}
+
+}
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
@@ -82,5 +82,12 @@ public class MeetingTemplateService {
 		return meetingTemplateMapper.toDetailDto(meetingTemplate);
 	}
 
+	@Transactional
+	public void deleteMeetingTemplate(long userId, String projectUrl, Long templateId) {
+		projectValidator.validateAccess(userId, projectUrl);
+
+		MeetingTemplate meetingTemplate = findById(templateId);
+		meetingTemplateRepository.delete(meetingTemplate);
+	}
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
@@ -13,6 +13,8 @@ import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.service.ProjectValidator;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateDetailResDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateResDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
@@ -70,6 +72,14 @@ public class MeetingTemplateService {
 		return meetingTemplates.stream()
 			.map(meetingTemplateMapper::toDto)
 			.toList();
+	}
+
+	@Transactional(readOnly = true)
+	public MeetingTemplateDetailResDto getMeetingTemplate(long userId, String projectUrl, Long templateId) {
+		projectValidator.validateAccess(userId, projectUrl);
+
+		MeetingTemplate meetingTemplate = findById(templateId);
+		return meetingTemplateMapper.toDetailDto(meetingTemplate);
 	}
 
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/template/service/MeetingTemplateService.java
@@ -1,5 +1,8 @@
 package scrumpledpaper.agiler.template.service;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -51,6 +54,22 @@ public class MeetingTemplateService {
 			meetingTemplateUpdateReqDto.description(),
 			meetingTemplateUpdateReqDto.contents()
 		);
+	}
+
+	private MeetingTemplate findById(Long id) {
+		return meetingTemplateRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.MEETING_TEMPLATE_NOT_FOUND));
+	}
+
+	@Transactional(readOnly = true)
+	public List<MeetingTemplateResDto> getMeetingTemplateList(long userId, String projectUrl) {
+		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
+		Project project = context.project();
+
+		List<MeetingTemplate> meetingTemplates = meetingTemplateRepository.findByProjectId(project.getId());
+		return meetingTemplates.stream()
+			.map(meetingTemplateMapper::toDto)
+			.toList();
 	}
 
 }

--- a/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
+++ b/apps/backend/src/main/resources/db/migration/V1__agiler_init.sql
@@ -219,6 +219,7 @@ CREATE TABLE `meeting_template` (
     `id` BIGINT PRIMARY KEY AUTO_INCREMENT,
     `project_id` BIGINT NOT NULL,
     `title` VARCHAR(20) NOT NULL,
+    `description` VARCHAR(100),
     `contents` TEXT,
     `created_at` DATETIME NOT NULL,
     `updated_at` DATETIME NOT NULL,

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/project/ProjectControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/project/ProjectControllerTest.java
@@ -33,9 +33,11 @@ import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Role;
 import scrumpledpaper.agiler.template.entity.DefaultIssueTemplate;
+import scrumpledpaper.agiler.template.entity.DefaultMeetingTemplate;
 import scrumpledpaper.agiler.template.entity.DefaultRetroTemplate;
 import scrumpledpaper.agiler.template.entity.DefaultScrumTemplate;
 import scrumpledpaper.agiler.template.entity.IssueTemplate;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 import scrumpledpaper.agiler.template.entity.RetroTemplate;
 import scrumpledpaper.agiler.template.entity.ScrumTemplate;
 
@@ -117,6 +119,9 @@ public class ProjectControllerTest {
 			DefaultRetroTemplate[] defaultRetroTemplates = DefaultRetroTemplate.values();
 			assertThat(retroTemplates).hasSize(defaultRetroTemplates.length);
 
+			List<MeetingTemplate> meetingTemplates = testDataFactory.findMeetingTemplatesByProjectId(createdProject.getId());
+			DefaultMeetingTemplate[] defaultMeetingTemplates = DefaultMeetingTemplate.values();
+			assertThat(meetingTemplates).hasSize(defaultMeetingTemplates.length);
 		}
 
 		@Test

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
@@ -273,5 +273,68 @@ public class MeetingTemplateControllerTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("get meeting template list")
+	class GetMeetingTemplateList {
+		@BeforeEach
+		void setUp() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - 회의 생성 템플릿 리스트 조회 성공")
+		public void getMeetingTemplateListSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			MeetingTemplate template1 = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template 1"
+			);
+			MeetingTemplate template2 = testDataFactory.createMeetingTemplate(
+				project,
+				"스프린트",
+				"스프린트 템플릿",
+				"Template 2"
+			);
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(template1.getTitle());
+			assertThat(response).contains(template2.getTitle());
+		}
+
+		@Test
+		@DisplayName("403 - 멤버가 아닌 사용자가 회의 생성 템플릿 리스트 조회 시도")
+		public void getMeetingTemplateListForbidden() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			testDataFactory.createProjectAndOwnerProfile(url, ownerAuth.getUser());
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+	}
+
 }
 

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
@@ -25,6 +25,7 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 
 @IntegrationTest
@@ -123,6 +124,144 @@ public class MeetingTemplateControllerTest {
 			// when
 			String response = mockMvc.perform(
 					post("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("update meeting template")
+	class UpdateMeetingTemplate {
+		private MeetingTemplate existingTemplate;
+
+		@BeforeEach
+		void setUp() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("204 - 회의 생성 템플릿 수정 성공")
+		public void meetingTemplateUpdateSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			existingTemplate = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Old Template"
+			);
+			MeetingTemplateUpdateReqDto updateReqDto = new MeetingTemplateUpdateReqDto(
+				existingTemplate.getId(),
+				"update template",
+				"update meeting template",
+				"Updated Template"
+			);
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNoContent())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			MeetingTemplate updatedTemplate = testDataFactory.findMeetingTemplateById(existingTemplate.getId());
+			assertThat(updatedTemplate.getTitle()).isEqualTo(updateReqDto.title());
+			assertThat(updatedTemplate.getDescription()).isEqualTo(updateReqDto.description());
+			assertThat(updatedTemplate.getContents()).isEqualTo(updateReqDto.contents());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 회의 템플릿 수정 시도")
+		public void meetingTemplateUpdateTemplateNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			MeetingTemplateUpdateReqDto updateReqDto = new MeetingTemplateUpdateReqDto(
+				9999L,
+				"update template",
+				"update meeting template",
+				"Updated Template"
+			);
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.MEETING_TEMPLATE_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("403 - 멤버가 아닌 사용자가 회의 생성 템플릿 수정 시도")
+		public void meetingTemplateUpdateForbidden() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			existingTemplate = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Old Template"
+			);
+			MeetingTemplateUpdateReqDto updateReqDto = new MeetingTemplateUpdateReqDto(
+				9999L,
+				"update template",
+				"update meeting template",
+				"Updated Template"
+			);
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", ownerAuth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트에 회의 템플릿 수정 시도")
+		public void meetingTemplateUpdateProjectNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "non_existing_url";
+			MeetingTemplateUpdateReqDto updateReqDto = new MeetingTemplateUpdateReqDto(
+				9999L,
+				"update template",
+				"update meeting template",
+				"Updated Template"
+			);
+			String updateJson = objectMapper.writeValueAsString(updateReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					put("/api/v1/projects/{projectUrl}/meetings/templates", url)
 						.cookie(new Cookie("accessToken", auth.getToken()))
 						.contentType(MediaType.APPLICATION_JSON)
 						.content(updateJson))

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
@@ -25,6 +25,7 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateDeleteReqDto;
 import scrumpledpaper.agiler.template.dto.MeetingTemplateUpdateReqDto;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 
@@ -425,5 +426,102 @@ public class MeetingTemplateControllerTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("delete meeting template")
+	class DeleteMeetingTemplate {
+		@BeforeEach
+		void setUp() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("204 - 회의 생성 템플릿 삭제 성공")
+		public void deleteMeetingTemplateSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			MeetingTemplate template = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template Detail"
+			);
+			MeetingTemplateDeleteReqDto deleteReqDto = new MeetingTemplateDeleteReqDto(template.getId());
+			String deleteJson = objectMapper.writeValueAsString(deleteReqDto);
+
+			// when
+			mockMvc.perform(
+					delete("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(deleteJson))
+				.andExpect(status().isNoContent())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThatThrownBy(() -> testDataFactory.findMeetingTemplateById(template.getId()))
+				.isInstanceOf(Exception.class);
+		}
+
+		@Test
+		@DisplayName("403 - 멤버가 아닌 사용자가 회의 생성 템플릿 삭제 시도")
+		public void deleteMeetingTemplateForbidden() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			MeetingTemplate template = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template Detail"
+			);
+			MeetingTemplateDeleteReqDto deleteReqDto = new MeetingTemplateDeleteReqDto(template.getId());
+			String deleteJson = objectMapper.writeValueAsString(deleteReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					delete("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", ownerAuth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(deleteJson))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 회의 템플릿 삭제 시도")
+		public void deleteMeetingTemplateNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template Detail"
+			);
+			MeetingTemplateDeleteReqDto deleteReqDto = new MeetingTemplateDeleteReqDto(9999L);
+			String deleteJson = objectMapper.writeValueAsString(deleteReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					delete("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(deleteJson))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.MEETING_TEMPLATE_NOT_FOUND.getMessage());
+		}
+	}
 }
 

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
@@ -1,0 +1,138 @@
+package scrumpledpaper.agiler.template;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.Cookie;
+import scrumpledpaper.agiler.annotation.IntegrationTest;
+import scrumpledpaper.agiler.common.AuthContext;
+import scrumpledpaper.agiler.common.TestDataFactory;
+import scrumpledpaper.agiler.common.exception.ErrorCode;
+import scrumpledpaper.agiler.image.entity.Image;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.template.dto.MeetingTemplateCreateReqDto;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
+
+@IntegrationTest
+@Transactional
+public class MeetingTemplateControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestDataFactory testDataFactory;
+	Image defaultImage;
+
+	@Nested
+	@DisplayName("Create Meeting Template")
+	class CreateMeetingTemplate {
+		@BeforeEach
+		void setUp() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("204 - 회의 생성 템플릿 생성 성공")
+		public void meetingTemplateCreateSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			MeetingTemplateCreateReqDto createReqDto = new MeetingTemplateCreateReqDto(
+				"회의 템플릿 제목",
+				"회의 템플릿 설명",
+				"회의 템플릿 내용"
+			);
+			String updateJson = objectMapper.writeValueAsString(createReqDto);
+
+			// when
+			mockMvc.perform(
+					post("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNoContent())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			List<MeetingTemplate> meetingTemplates = testDataFactory.findMeetingTemplatesByProjectId(project.getId());
+			assertThat(meetingTemplates)
+				.anyMatch(meetingTemplate ->
+					meetingTemplate.getTitle().equals(createReqDto.title()) &&
+					meetingTemplate.getDescription().equals(createReqDto.description()) &&
+					meetingTemplate.getContents().equals(createReqDto.contents())
+				);
+		}
+
+		@Test
+		@DisplayName("403 - 멤버가 아닌 사용자가 회의 생성 템플릿 생성 시도")
+		public void meetingTemplateCreateForbidden() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			testDataFactory.createProjectAndOwnerProfile(url, ownerAuth.getUser());
+			MeetingTemplateCreateReqDto createReqDto = new MeetingTemplateCreateReqDto(
+				"회의 템플릿 제목",
+				"회의 템플릿 설명",
+				"회의 템플릿 내용"
+			);
+			String updateJson = objectMapper.writeValueAsString(createReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					post("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트에 회의 템플릿 생성 시도")
+		public void meetingTemplateCreateProjectNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "non_existing_url";
+			MeetingTemplateCreateReqDto createReqDto = new MeetingTemplateCreateReqDto(
+				"회의 템플릿 제목",
+				"회의 템플릿 설명",
+				"회의 템플릿 내용"
+			);
+			String updateJson = objectMapper.writeValueAsString(createReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					post("/api/v1/projects/{projectUrl}/meetings/templates", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+	}
+
+}
+

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/template/MeetingTemplateControllerTest.java
@@ -336,5 +336,94 @@ public class MeetingTemplateControllerTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("get meeting template detail")
+	class GetMeetingTemplateDetail {
+		@BeforeEach
+		void setUp() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - 회의 생성 템플릿 상세 조회 성공")
+		public void getMeetingTemplateDetailSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			MeetingTemplate template = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template Detail"
+			);
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/meetings/templates/{templateId}", url, template.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(template.getTitle());
+			assertThat(response).contains(template.getContents());
+		}
+
+		@Test
+		@DisplayName("403 - 멤버가 아닌 사용자가 회의 생성 템플릿 상세 조회 시도")
+		public void getMeetingTemplateDetailForbidden() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url,	auth.getUser());
+			MeetingTemplate template = testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template Detail"
+			);
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/meetings/templates/{templateId}", url, template.getId())
+						.cookie(new Cookie("accessToken", ownerAuth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 회의 템플릿 상세 조회 시도")
+		public void getMeetingTemplateDetailNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test_url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			testDataFactory.createMeetingTemplate(
+				project,
+				"회의",
+				"회의 템플릿",
+				"Template Detail"
+			);
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/meetings/templates/{templateId}", url, 9999L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.MEETING_TEMPLATE_NOT_FOUND.getMessage());
+		}
+	}
+
 }
 

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
@@ -229,6 +229,15 @@ public class TestDataFactory {
 		return meetingTemplateRepository.findByProjectId(projectId);
 	}
 
+	public MeetingTemplate createMeetingTemplate(Project project, String title, String description, String contents) {
+		MeetingTemplate meetingTemplate = MeetingTemplateFixture.createMeetingTemplate(
+			project,
+			title,
+			description,
+			contents
+		);
+		return meetingTemplateRepository.save(meetingTemplate);
+	}
 
 	public MeetingTemplate findMeetingTemplateById(Long id) {
 		return meetingTemplateRepository.findById(id).orElseThrow();

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
@@ -14,9 +14,11 @@ import scrumpledpaper.agiler.project.entity.Role;
 import scrumpledpaper.agiler.project.repository.ProfileRepository;
 import scrumpledpaper.agiler.project.repository.ProjectRepository;
 import scrumpledpaper.agiler.template.entity.IssueTemplate;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 import scrumpledpaper.agiler.template.entity.RetroTemplate;
 import scrumpledpaper.agiler.template.entity.ScrumTemplate;
 import scrumpledpaper.agiler.template.repository.IssueTemplateRepository;
+import scrumpledpaper.agiler.template.repository.MeetingTemplateRepository;
 import scrumpledpaper.agiler.template.repository.RetroTemplateRepository;
 import scrumpledpaper.agiler.template.repository.ScrumTemplateRepository;
 import scrumpledpaper.agiler.user.entity.User;
@@ -38,6 +40,7 @@ public class TestDataFactory {
 	private final IssueTemplateRepository issueTemplateRepository;
 	private final ScrumTemplateRepository scrumTemplateRepository;
 	private final RetroTemplateRepository retroTemplateRepository;
+	private final MeetingTemplateRepository meetingTemplateRepository;
 	private final EntityManager entityManager;
 
 	public Image createDefaultImage() {
@@ -220,6 +223,10 @@ public class TestDataFactory {
 
 	public RetroTemplate findRetroTemplateById(Long id) {
 		return retroTemplateRepository.findById(id).orElseThrow();
+	}
+
+	public List<MeetingTemplate> findMeetingTemplatesByProjectId(Long projectId) {
+		return meetingTemplateRepository.findByProjectId(projectId);
 	}
 
 }

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
@@ -229,4 +229,8 @@ public class TestDataFactory {
 		return meetingTemplateRepository.findByProjectId(projectId);
 	}
 
+
+	public MeetingTemplate findMeetingTemplateById(Long id) {
+		return meetingTemplateRepository.findById(id).orElseThrow();
+	}
 }

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/MeetingTemplateFixture.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/fixture/MeetingTemplateFixture.java
@@ -1,0 +1,16 @@
+package scrumpledpaper.agiler.fixture;
+
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.template.entity.MeetingTemplate;
+
+public class MeetingTemplateFixture {
+	public static MeetingTemplate createMeetingTemplate(Project project, String title, String description, String contents) {
+		return MeetingTemplate.builder()
+			.project(project)
+			.title(title)
+			.description(description)
+			.contents(contents)
+			.build();
+	}
+}
+


### PR DESCRIPTION
## 🚀 기능 개요

Meeting를 생성시 사용할 Template 관련 API를 작성했습니다.

## 🧩 작업 사항

- Meeting Template 생성 API 및 테스트 코드 작성
- Meeting Template 수정 API 및 테스트 코드 작성
- Meeting Template 삭제 API 및 테스트 코드 작성
- Meeting Template List 조회 API 및 테스트 코드 작성
- Meeting Template 단일 상세조회 API 및 테스트 코드 작성

## 🔄 변경 로직

- DB의 Meeting Template에 누락된 Descreption 추가

## 🗂️ 이슈 번호
- closed #79 