### PR TITLE
[Bug] 🐛 Github OAuth 로그인시 name null guard

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/oauth2/ProviderType.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/oauth2/ProviderType.java
@@ -1,5 +1,6 @@
 package scrumpledpaper.agiler.auth.oauth2;
 
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import scrumpledpaper.agiler.auth.oauth2.userinfo.GitHubOAuth2UserInfo;
 import scrumpledpaper.agiler.auth.oauth2.userinfo.GoogleOAuth2UserInfo;
 import scrumpledpaper.agiler.auth.oauth2.userinfo.OAuth2UserInfo;
@@ -25,7 +26,7 @@ public enum ProviderType {
 				return type;
 			}
 		}
-		throw new IllegalArgumentException("Unsupported provider: " + registrationId);
+		throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
 	}
 
 	public OAuth2UserInfo getOAuth2UserInfo(Map<String, Object> attributes) {

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/oauth2/userinfo/GitHubOAuth2UserInfo.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/oauth2/userinfo/GitHubOAuth2UserInfo.java
@@ -15,7 +15,7 @@ public class GitHubOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getName() {
-        return (String) attributes.get("name");
+        return (String) attributes.get("login");
     }
 
     @Override

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/service/CustomOAuth2UserService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/service/CustomOAuth2UserService.java
@@ -32,7 +32,10 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		ProviderType providerType = ProviderType.from(registrationId);
 		OAuth2UserInfo oAuth2UserInfo = providerType.getOAuth2UserInfo(oAuth2User.getAttributes());
 
-		User user = userRepository.findByEmail(oAuth2UserInfo.getEmail())
+		User user = userRepository.findByVendorAndVendorId(
+						registrationId,
+						oAuth2UserInfo.getId()
+				)
 				.orElseGet(() -> createUser(oAuth2UserInfo, registrationId));
 
 		String nameAttributeKey = userRequest.getClientRegistration()
@@ -49,7 +52,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 	private User createUser(OAuth2UserInfo userInfo, String registrationId) {
 		User newUser = User.builder()
 				.email(userInfo.getEmail())
-				.nickname(userInfo.getName()) // Consider potential nickname duplication
+				.nickname(userInfo.getName())
 				.vendor(registrationId)
 				.vendorId(userInfo.getId())
 				.imageId(DEFAULT_IMAGE_ID)

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/service/CustomOAuth2UserService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/service/CustomOAuth2UserService.java
@@ -33,10 +33,10 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		OAuth2UserInfo oAuth2UserInfo = providerType.getOAuth2UserInfo(oAuth2User.getAttributes());
 
 		User user = userRepository.findByVendorAndVendorId(
-						registrationId,
+						providerType,
 						oAuth2UserInfo.getId()
 				)
-				.orElseGet(() -> createUser(oAuth2UserInfo, registrationId));
+				.orElseGet(() -> createUser(oAuth2UserInfo, providerType));
 
 		String nameAttributeKey = userRequest.getClientRegistration()
 				.getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
@@ -49,11 +49,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 		);
 	}
 
-	private User createUser(OAuth2UserInfo userInfo, String registrationId) {
+	private User createUser(OAuth2UserInfo userInfo, ProviderType providerType) {
 		User newUser = User.builder()
 				.email(userInfo.getEmail())
 				.nickname(userInfo.getName())
-				.vendor(registrationId)
+				.vendor(providerType)
 				.vendorId(userInfo.getId())
 				.imageId(DEFAULT_IMAGE_ID)
 				.build();

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
 			"/v3/api-docs/**",
 			"/swagger-ui/**",
 			/* auth */
-			"/api/v1/auth/**",
+			"/api/v1/login/**",
 			/* health check */
 			"/actuator/**"
 	};

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/dto/UserDto.java
@@ -2,13 +2,14 @@ package scrumpledpaper.agiler.user.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import scrumpledpaper.agiler.auth.oauth2.ProviderType;
 import scrumpledpaper.agiler.user.entity.User;
 
 @Getter
 @Builder
 public class UserDto {
 	private Long id;
-	private String vendor;
+	private ProviderType vendor;
 	private String vendorId;
 	private String email;
 	private String nickname;

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/entity/User.java
@@ -2,6 +2,8 @@ package scrumpledpaper.agiler.user.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -10,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import scrumpledpaper.agiler.auth.oauth2.ProviderType;
 import scrumpledpaper.agiler.common.BaseEntity;
 
 @Getter
@@ -24,8 +27,9 @@ public class User extends BaseEntity {
 	@Column(name = "id")
 	private Long id;
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "vendor")
-	private String vendor;
+	private ProviderType vendor;
 
 	@Column(name = "vendor_id")
 	private String vendorId;

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
+	Optional<User> findByVendorAndVendorId(String vendor, String vendorId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java
@@ -1,11 +1,12 @@
 package scrumpledpaper.agiler.user.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import scrumpledpaper.agiler.auth.oauth2.ProviderType;
 import scrumpledpaper.agiler.user.entity.User;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(String email);
-	Optional<User> findByVendorAndVendorId(String vendor, String vendorId);
+	Optional<User> findByVendorAndVendorId(ProviderType vendor, String vendorId);
 }

--- a/apps/frontend/src/api/services/authService.test.ts
+++ b/apps/frontend/src/api/services/authService.test.ts
@@ -29,7 +29,7 @@ describe('authService', () => {
 
       const user = await authService.getCurrentUser()
 
-      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users/')
+      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users')
       expect(user).toEqual(mockUser)
       expect(user.id).toBe(1)
       expect(user.email).toBe('test@agiler.com')
@@ -48,7 +48,7 @@ describe('authService', () => {
 
       const user = await authService.getCurrentUser()
 
-      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users/')
+      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users')
       expect(user).toEqual(mockUser)
       expect(user.imageUrl).toBeUndefined()
     })
@@ -60,7 +60,7 @@ describe('authService', () => {
       await expect(authService.getCurrentUser()).rejects.toThrow(
         'Network Error'
       )
-      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users/')
+      expect(apiClient.get).toHaveBeenCalledWith('/api/v1/users')
     })
   })
 

--- a/apps/frontend/src/api/services/authService.ts
+++ b/apps/frontend/src/api/services/authService.ts
@@ -23,7 +23,7 @@ export const authService = {
    * 현재 로그인한 사용자 정보 조회
    */
   getCurrentUser: async (): Promise<User> => {
-    const response = await apiClient.get<User>('/api/v1/users/')
+    const response = await apiClient.get<User>('/api/v1/users')
     return response.data
   },
 }

--- a/apps/frontend/src/components/auth/ProtectedRoute.integration.test.tsx
+++ b/apps/frontend/src/components/auth/ProtectedRoute.integration.test.tsx
@@ -105,10 +105,10 @@ describe('ProtectedRoute - 통합 테스트', () => {
     it('인증되지 않은 사용자는 로그인 페이지로 리다이렉트된다', async () => {
       // Given: API가 401 에러를 반환하도록 설정
       server.use(
-        http.get('/api/v1/users/', () => {
+        http.get('/api/v1/users', () => {
           return new HttpResponse(null, { status: 401 })
         }),
-        http.get(`${API_BASE_URL}/api/v1/users/`, () => {
+        http.get(`${API_BASE_URL}/api/v1/users`, () => {
           return new HttpResponse(null, { status: 401 })
         })
       )
@@ -141,8 +141,8 @@ describe('ProtectedRoute - 통합 테스트', () => {
     it('네트워크 에러 시 로그인 페이지로 리다이렉트된다', async () => {
       // Given: API가 네트워크 에러를 반환
       server.use(
-        http.get('/api/v1/users/', () => HttpResponse.error()),
-        http.get(`${API_BASE_URL}/api/v1/users/`, () => HttpResponse.error())
+        http.get('/api/v1/users', () => HttpResponse.error()),
+        http.get(`${API_BASE_URL}/api/v1/users`, () => HttpResponse.error())
       )
 
       // When: ProtectedRoute 렌더링

--- a/apps/frontend/src/mocks/handlers.ts
+++ b/apps/frontend/src/mocks/handlers.ts
@@ -43,7 +43,7 @@ const createPatchHandlers = (
 
 export const handlers = [
   // 현재 사용자 정보 조회
-  ...createHandlers('/api/v1/users/', () => {
+  ...createHandlers('/api/v1/users', () => {
     return HttpResponse.json(MOCK_USER)
   }),
 

--- a/apps/frontend/src/pages/Home.integration.test.tsx
+++ b/apps/frontend/src/pages/Home.integration.test.tsx
@@ -136,10 +136,10 @@ describe('Home Page - 통합 테스트', () => {
 
       // Given: API가 401 에러를 반환 (비인증 상태)
       server.use(
-        http.get('/api/v1/users/', () => {
+        http.get('/api/v1/users', () => {
           return new HttpResponse(null, { status: 401 })
         }),
-        http.get(`${API_BASE_URL}/api/v1/users/`, () => {
+        http.get(`${API_BASE_URL}/api/v1/users`, () => {
           return new HttpResponse(null, { status: 401 })
         })
       )
@@ -168,8 +168,8 @@ describe('Home Page - 통합 테스트', () => {
 
       // Given: API가 네트워크 에러를 반환
       server.use(
-        http.get('/api/v1/users/', () => HttpResponse.error()),
-        http.get(`${API_BASE_URL}/api/v1/users/`, () => HttpResponse.error())
+        http.get('/api/v1/users', () => HttpResponse.error()),
+        http.get(`${API_BASE_URL}/api/v1/users`, () => HttpResponse.error())
       )
 
       render(<Home />, { wrapper: createWrapper() })


### PR DESCRIPTION
## 🚀 기능 개요
OAuth2 인증 흐름에서 유저 식별 기준을 이메일에서 `vendor + vendorId` 조합으로 변경하고, GitHub 사용자 정보 매핑 및 인증 관련 public 라우트를 정리했습니다. 이를 통해 소셜 로그인 시 동일 유저를 더 안정적으로 식별하고, 인증 API의 역할을 명확히 합니다.

## 🧩 작업 사항
- `CustomOAuth2UserService`에서 유저 조회 로직을 `findByEmail` → `findByVendorAndVendorId`로 변경  
  - `apps/backend/src/main/java/scrumpledpaper/agiler/auth/service/CustomOAuth2UserService.java`
- 새로운 조회 전략을 지원하기 위해 `UserRepository`에 `findByVendorAndVendorId` 메서드 추가  
  - `apps/backend/src/main/java/scrumpledpaper/agiler/user/repository/UserRepository.java`
- GitHub OAuth2 유저 정보 매핑 시 `name` 대신 `login` 속성을 닉네임 소스로 사용하도록 변경  
  - `apps/backend/src/main/java/scrumpledpaper/agiler/auth/oauth2/userinfo/GitHubOAuth2UserInfo.java`
- Spring Security 설정에서 인증 관련 public 라우트를 `/api/v1/auth/**` → `/api/v1/login/**` 로 변경  
  - `apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java`
- 프론트엔드 auth 서비스에서 유저 정보 조회 endpoint의 trailing slash 제거  
  - `apps/frontend/src/api/services/authService.ts`

## 🔄 변경 로직
- **유저 식별 기준 변경**
  - 이전: OAuth2 로그인 시 이메일을 기준으로 `User` 조회 (`findByEmail`)
  - 변경: `vendor`(공급자) + `vendorId`(공급자별 유저 고유 ID) 조합으로 `User` 조회 (`findByVendorAndVendorId`)
  - 효과: 동일 이메일을 사용하는 다른 OAuth 계정과의 충돌을 방지하고, 벤더별로 안정적인 유저 식별 가능
- **GitHub 유저 정보 매핑 보정**
  - GitHub의 `name` 필드가 비어 있거나 일관되지 않은 경우가 있어, 로그인 ID인 `login` 값을 닉네임/표시 이름 기준으로 사용
- **인증 라우트 swagger에 맞게 변경**
  - `/api/v1/auth/**` → `/api/v1/login/**`로 변경하여, 해당 API가 “인증 처리”보다는 “로그인 엔드포인트”임을 명확히 함
- **프론트엔드 API 호출 안정화**
  - trailing slash 제거로 백엔드 라우팅과의 불필요한 mismatch 가능성 감소

## 🗂️ 이슈 번호
- Closed #78 