### PR TITLE
[Bug] 🐛 Backend CD 실행이 안 되는 버그

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
+          cache: 'gradle'
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew
@@ -39,7 +40,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: "apps/backend/build/libs/*.jar"
-          target: "/home/ubuntu/backend"
+          target: "/home/ubuntu/backend/app.jar"
           strip_components: 4
 
       - name: Execute deployment script on server
@@ -51,17 +52,40 @@ jobs:
           script: |
             DEPLOY_PATH="/home/ubuntu/backend"
             CONFIG_PATH="$DEPLOY_PATH/config"
-            JAR_NAME=$(ls -t $DEPLOY_PATH/*.jar | head -n 1)
+            JAR_PATH="$DEPLOY_PATH/app.jar"
 
             # Create configuration directory
             mkdir -p $CONFIG_PATH
 
             # Create application.yml from GitHub Secret
-            echo "${{ secrets.APPLICATION_YML }}" > $CONFIG_PATH/application.yml
+            cat <<'EOF' > $CONFIG_PATH/application.yml
+            ${{ secrets.APPLICATION_YML }}
+            EOF
 
             # Stop any old running process
-            pkill -f "$JAR_NAME" || true
-            sleep 5
+            pkill -f "$JAR_PATH" || true
+            # Wait until the port is released
+            echo "Waiting for port 8080 to be released..."
+            while lsof -i :8080 > /dev/null
+            do
+            sleep 1
+            done
+            echo "Port 8080 is free."
 
             # Start the new application with external config
-            nohup java -jar $JAR_NAME --spring.config.location=$CONFIG_PATH/application.yml > $DEPLOY_PATH/app.log 2>&1 &
+            nohup java -jar $JAR_PATH --spring.config.location=$CONFIG_PATH/application.yml > $DEPLOY_PATH/app.log 2>&1 &
+
+            echo "Waiting for application to start..."
+            sleep 15
+            for i in {1..10}
+            do
+              response=$(curl -s http://127.0.0.1:8080/actuator/health)
+              if [[ "$response" == *"UP"* ]]; then
+                echo "Application started successfully!"
+                exit 0
+              fi
+              echo "Application not up yet. Retrying in 5 seconds..."
+              sleep 5
+            done
+            echo "Application failed to start."
+            exit 1 # 헬스체크 실패 시 워크플로우를 실패 처리


### PR DESCRIPTION
## 🚀 기능 개요

- 백엔드 배포 워크플로우를 안정적이고 일관되게 동작하도록 개선했습니다.
- 배포 산출물(app.jar) 명세를 고정하고, 배포 스크립트에 헬스 체크와 포트 점유 해제 대기 로직을 추가했으며, Gradle 빌드 캐시를 활성화해 빌드 성능을 최적화했습니다.

## 🧩 작업 사항

- **배포 산출물 표준화**
    - 배포되는 JAR 파일명을 항상 app.jar로 고정
    - 배포 경로를 /home/ubuntu/backend/app.jar로 통일하여 프로세스 관리 및 이후 배포 스크립트 유지보수 용이성 확보
- **배포 스크립트 개선**
    - 애플리케이션 기동 후 헬스 체크를 수행하도록 스크립트 개선
        - 서버가 정상 기동되기 전까지 대기 후 성공 여부 판단
        - 헬스 체크 실패 시 워크플로우가 실패하도록 처리하여 문제 조기 감지
    - 신규 프로세스 기동 전에 **8080 포트가 해제될 때까지 대기**하도록 로직 추가
        - 포트 충돌로 인한 배포 실패/장애 방지
- **빌드 성능 최적화**
    - GitHub Actions 워크플로우에서 **Gradle 빌드 캐시 활성화**
    - 이전에 다운로드한 의존성을 재사용하여 빌드 시간 단축
- **환경 설정(application.yml) 처리 방식 개선**
    - application.yml을 heredoc으로 작성하도록 변경

## 🔄 변경 로직

- 배포 순서 개요
    1. Gradle 빌드 시 캐시를 활용하여 빌드 수행
    2. 빌드 결과물을 app.jar로 이름 고정 후 /home/ubuntu/backend/app.jar 경로에 배치
    3. 기존 애플리케이션이 사용 중인 **8080 포트가 해제될 때까지 대기**
    4. 새 app.jar 프로세스 실행
    5. 애플리케이션 헬스 체크 수행
        - 응답이 정상일 경우 배포 성공으로 처리
        - 응답 실패 또는 타임아웃 시 워크플로우 실패로 간주하여 문제를 즉시 드러냄
    6. 배포 과정 중 application.yml은 heredoc을 통해 작성 및 반영

## 🗂️ 이슈 번호
- Closed #98 
