### PR TITLE
[Bug] 🐛 Backend CD 무한루프 및 Health Check

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -40,7 +40,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: "apps/backend/build/libs/*.jar"
-          target: "/home/ubuntu/backend/app.jar"
+          target: "/home/ubuntu/backend"
           strip_components: 4
 
       - name: Execute deployment script on server
@@ -50,42 +50,68 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
+            set -e
+
             DEPLOY_PATH="/home/ubuntu/backend"
             CONFIG_PATH="$DEPLOY_PATH/config"
             JAR_PATH="$DEPLOY_PATH/app.jar"
 
-            # Create configuration directory
-            mkdir -p $CONFIG_PATH
+            # 1. Create configuration directory
+            mkdir -p "$CONFIG_PATH"
 
-            # Create application.yml from GitHub Secret
-            cat <<'EOF' > $CONFIG_PATH/application.yml
+            # 2. GitHub Secret에서 application.yml 생성
+            cat <<'EOF' > "$CONFIG_PATH/application.yml"
             ${{ secrets.APPLICATION_YML }}
             EOF
 
-            # Stop any old running process
-            pkill -f "$JAR_PATH" || true
-            # Wait until the port is released
-            echo "Waiting for port 8080 to be released..."
-            while lsof -i :8080 > /dev/null
-            do
-            sleep 1
-            done
-            echo "Port 8080 is free."
+            # 3. 가장 최근에 업로드된 JAR를 app.jar 이름으로 표준화
+            LATEST_JAR=$(ls -t "$DEPLOY_PATH"/*.jar | head -n 1 || true)
+            if [ -z "$LATEST_JAR" ]; then
+              echo "No jar file found in $DEPLOY_PATH"
+              exit 1
+            fi
 
-            # Start the new application with external config
-            nohup java -jar $JAR_PATH --spring.config.location=$CONFIG_PATH/application.yml > $DEPLOY_PATH/app.log 2>&1 &
+            echo "Latest jar: $LATEST_JAR"
+            cp "$LATEST_JAR" "$JAR_PATH"
+
+            # 4. 8080 포트를 사용 중인 프로세스 정리
+            PIDS=$(lsof -ti :8080 || true)
+            if [ -n "$PIDS" ]; then
+              echo "Killing processes on port 8080: $PIDS"
+              kill $PIDS || true
+            fi
+
+            echo "Waiting for port 8080 to be released (max 30s)..."
+            for i in $(seq 1 30); do
+              if ! lsof -i :8080 > /dev/null; then
+                echo "Port 8080 is free."
+                break
+              fi
+              sleep 1
+            done
+
+            if lsof -i :8080 > /dev/null; then
+              echo "Port 8080 is still in use after 30 seconds."
+              exit 1
+            fi
+
+            # 5. 새로운 앱 실행 (외부 설정 파일 사용)
+            echo "Starting application..."
+            nohup java -jar "$JAR_PATH" --spring.config.location="$CONFIG_PATH/application.yml" > "$DEPLOY_PATH/app.log" 2>&1 &
 
             echo "Waiting for application to start..."
-            sleep 15
-            for i in {1..10}
-            do
-              response=$(curl -s http://127.0.0.1:8080/actuator/health)
-              if [[ "$response" == *"UP"* ]]; then
+            sleep 10
+
+            # 6. 헬스 체크로 기동 여부 확인
+            for i in $(seq 1 10); do
+              response=$(curl -s http://127.0.0.1:8080/actuator/health || true)
+              if echo "$response" | grep -q "UP"; then
                 echo "Application started successfully!"
                 exit 0
               fi
-              echo "Application not up yet. Retrying in 5 seconds..."
+              echo "Health check failed (attempt $i/10). Retrying in 5 seconds..."
               sleep 5
             done
+
             echo "Application failed to start."
-            exit 1 # 헬스체크 실패 시 워크플로우를 실패 처리
+            exit 1


### PR DESCRIPTION
## 🚀 기능 개요

- JAR 배포 방식, 실행 중인 프로세스/포트 처리, 헬스 체크 로직을 정리해서 재배포 시 충돌을 줄이고 실패를 더 빠르게 감지하도록 했습니다.


## 🧩 작업 사항

- **JAR 배포 경로 및 파일명 표준화**
    - JAR 배포 타깃을 단일 파일 경로(/home/ubuntu/backend/app.jar)가 아니라 **디렉터리(/home/ubuntu/backend) 기준**으로 변경
    - 서버 배포 스크립트에서 **가장 최근에 업로드된 JAR 파일을 찾아 app.jar로 복사**하도록 처리
    - 대상 디렉터리에 JAR가 하나도 없는 경우 **에러 로그 출력 후 배포 실패 처리**를 추가해 방어적 코드 강화
- **프로세스 및 포트(8080) 관리 강화**
    - 배포 전, lsof -ti :8080으로 **8080 포트를 점유 중인 프로세스들을 강제 종료**하도록 수정
    - 포트가 완전히 해제될 때까지 **최대 30초 동안 대기**하도록 루프를 추가
    - 30초 이후에도 8080 포트가 사용 중이면 **배포를 실패 처리**하여, 새로운 애플리케이션이 깨끗한 상태에서 뜨지 못하는 상황을 조기에 감지
- **헬스 체크 및 기동 로직 개선**
    - 앱 기동 후 /actuator/health 엔드포인트에 대해 **최대 10회까지 재시도**하도록 변경
    - 각 시도마다 로그를 남겨, 몇 번째 시도에서 실패/성공했는지 로그로 확인 가능
    - 10회 시도 내에 "UP" 상태를 받지 못하면 **명시적으로 배포를 실패(exit 1)** 시켜 문제를 바로 알 수 있도록 함

## 🔄 변경 로직

1.	GitHub Actions에서 백엔드를 bootJar로 빌드하고, 생성된 JAR를 /home/ubuntu/backend 디렉터리로 전송
2.	서버 스크립트에서 /home/ubuntu/backend 내 가장 최신 JAR 파일을 탐색 후, 이를 /home/ubuntu/backend/app.jar로 복사하여 실행 기준 파일명 표준화
3.	배포 전에 lsof -ti :8080으로 8080 포트를 점유 중인 프로세스를 찾아 kill 수행
4.	최대 30초 동안 8080 포트가 해제될 때까지 대기
  •	아직 사용 중이면 배포 실패 처리
5.	포트가 비워지면 app.jar를 외부 설정(application.yml)과 함께 nohup으로 실행
6.	기동 후 10회까지 /actuator/health 헬스 체크를 수행
  •	"UP" 응답 시 배포 성공
  •	연속 실패 시 워크플로우를 실패 처리하여 문제를 즉시 드러냄

## 🗂️ 이슈 번호

- Closed #100 