### PR TITLE
BE] ✨ Issue 시작 / 종료 시간 수정 API, Issue 상세 조회 API

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
@@ -44,6 +44,8 @@ public enum ErrorCode {
 	INVALID_KANBAN_CONFIG_PRIORITY_ORDER(400, "K007", "칸반 설정의 우선순위가 올바르지 않습니다."),
 
 	ISSUE_NOT_FOUND(404, "IS001", "이슈를 찾을 수 없습니다."),
+	ISSUE_INVALID_DATE_RANGE(400, "IS002", "이슈의 시작시간은 종료시간보다 이전이어야 합니다."),
+	ISSUE_DATE_MUST_TODAY(400, "IS003", "이슈 시간은 당일만 설정할 수 있습니다."),
 
 	NOTIFICATION_CHANNEL_NOT_FOUND(404, "N001", "알림 채널을 찾을 수 없습니다."),
 	SLACK_OAUTH_FAILED(400, "N002", "Slack OAuth 인증에 실패했습니다."),

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/controller/IssueController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/controller/IssueController.java
@@ -21,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.kanban.dto.IssueAssigneesReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDateUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDeleteReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueIdResDto;
@@ -118,5 +119,16 @@ public class IssueController {
 		@PathVariable Long issueId) {
 		IssueDetailResDto issueDetailResDto = issueService.getIssueDetail(customUserDetails.getUserId(), projectUrl, issueId);
 		return ResponseEntity.ok(issueDetailResDto);
+	}
+
+	@PatchMapping("/{projectUrl}/issues/{issueId}/date")
+	public ResponseEntity<IssueIdResDto> updateIssueDate(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable Long issueId,
+		@RequestBody IssueDateUpdateReqDto request) {
+		long updatedIssueId = issueService.updateIssueDate(customUserDetails.getUserId(), projectUrl, issueId, request);
+		return ResponseEntity.ok(new IssueIdResDto(updatedIssueId));
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/controller/IssueController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/controller/IssueController.java
@@ -22,6 +22,7 @@ import scrumpledpaper.agiler.auth.service.CustomUserDetails;
 import scrumpledpaper.agiler.kanban.dto.IssueAssigneesReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDeleteReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueIdResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueKanbanConfigUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueLabelsReqDto;
@@ -107,5 +108,15 @@ public class IssueController {
 		@RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 		KanbanBoardResDto kanbanBoardResDto = issueService.getKanbanBoard(customUserDetails.getUserId(), projectUrl, date);
 		return ResponseEntity.ok(kanbanBoardResDto);
+	}
+
+	@GetMapping("/{projectUrl}/issues/{issueId}")
+	public ResponseEntity<IssueDetailResDto> getIssueDetail(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable Long issueId) {
+		IssueDetailResDto issueDetailResDto = issueService.getIssueDetail(customUserDetails.getUserId(), projectUrl, issueId);
+		return ResponseEntity.ok(issueDetailResDto);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/dto/IssueDateUpdateReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/dto/IssueDateUpdateReqDto.java
@@ -1,0 +1,13 @@
+package scrumpledpaper.agiler.kanban.dto;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+public record IssueDateUpdateReqDto(
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
+	Optional<LocalDateTime> startedAt,
+	@JsonInclude(JsonInclude.Include.NON_ABSENT)
+	Optional<LocalDateTime> dueAt
+) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/dto/IssueDetailResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/dto/IssueDetailResDto.java
@@ -1,0 +1,43 @@
+package scrumpledpaper.agiler.kanban.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record IssueDetailResDto(
+	long issueId,
+	String title,
+	KanbanConfigDto kanbanConfig,
+	boolean isDone,
+	String contents,
+	LocalDateTime createdAt,
+	List<AssigneeDto> assignees,
+	List<LabelDto> labels,
+	LocalDateTime startedAt,
+	LocalDateTime dueAt
+) {
+
+	public record KanbanConfigDto(
+		long kanbanConfigId,
+		String statusName,
+		Integer priority,
+		Boolean isDefault,
+		Boolean backlog,
+		Boolean isDone
+	) {}
+
+	public record AssigneeDto(
+		long profileId,
+		String nickname,
+		String email,
+		String imageUrl,
+		String role,
+		String description
+	) {}
+
+	public record LabelDto(
+		long labelId,
+		String name,
+		String color,
+		String description
+	) {}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Issue.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/entity/Issue.java
@@ -77,4 +77,9 @@ public class Issue extends BaseEntity {
 		this.kanbanConfig = kanbanConfig;
 		this.isDone = kanbanConfig.getIsDone();
 	}
+
+	public void updateIssueDate(LocalDateTime startedAt, LocalDateTime dueAt) {
+		this.startedAt = startedAt;
+		this.dueAt = dueAt;
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/IssueMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/IssueMapper.java
@@ -100,6 +100,8 @@ public interface IssueMapper {
 	@Mapping(target = "issueId", source = "issue.id")
 	@Mapping(target = "isDone", source = "issue.isDone")
 	@Mapping(target = "createdAt", source = "issue.createdAt")
+	@Mapping(target = "assignees", source = "assignees")
+	@Mapping(target = "labels", source = "labels")
 	@Mapping(target = "kanbanConfig.kanbanConfigId", source = "kanbanConfig.id")
 	@Mapping(target = "kanbanConfig.statusName", source = "kanbanConfig.statusName")
 	@Mapping(target = "kanbanConfig.priority", source = "kanbanConfig.priority")

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/IssueMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/IssueMapper.java
@@ -9,6 +9,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanBoardResDto;
 import scrumpledpaper.agiler.kanban.entity.Issue;
 import scrumpledpaper.agiler.kanban.entity.IssueLabel;
@@ -95,4 +96,15 @@ public interface IssueMapper {
 			issue.getDueAt()
 		);
 	}
+
+	@Mapping(target = "issueId", source = "issue.id")
+	@Mapping(target = "isDone", source = "issue.isDone")
+	@Mapping(target = "createdAt", source = "issue.createdAt")
+	@Mapping(target = "kanbanConfig.kanbanConfigId", source = "kanbanConfig.id")
+	@Mapping(target = "kanbanConfig.statusName", source = "kanbanConfig.statusName")
+	@Mapping(target = "kanbanConfig.priority", source = "kanbanConfig.priority")
+	@Mapping(target = "kanbanConfig.isDefault", source = "kanbanConfig.defaultStatus")
+	@Mapping(target = "kanbanConfig.backlog", source = "kanbanConfig.backlog")
+	@Mapping(target = "kanbanConfig.isDone", source = "kanbanConfig.isDone")
+	IssueDetailResDto toIssueDetailDto(Issue issue, List<IssueDetailResDto.LabelDto> labels, List<IssueDetailResDto.AssigneeDto> assignees, KanbanConfig kanbanConfig);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/KanbanConfigMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/KanbanConfigMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanBoardResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanConfigResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanConfigUpdateReqDto;
@@ -29,4 +30,8 @@ public interface KanbanConfigMapper {
 	@Mapping(target = "kanbanConfigId", source = "kanbanConfig.id")
 	@Mapping(target = "isDefault", source = "kanbanConfig.defaultStatus")
 	KanbanBoardResDto.KanbanConfigDto toKanbanBoardDto(KanbanConfig kanbanConfig);
+
+	@Mapping(target = "kanbanConfigId", source = "kanbanConfig.id")
+	@Mapping(target = "isDefault", source = "kanbanConfig.defaultStatus")
+	IssueDetailResDto.KanbanConfigDto toIssueDetailDto(KanbanConfig kanbanConfig);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/LabelMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/mapper/LabelMapper.java
@@ -3,6 +3,7 @@ package scrumpledpaper.agiler.kanban.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanBoardResDto;
 import scrumpledpaper.agiler.kanban.dto.LabelCreateReqDto;
 import scrumpledpaper.agiler.kanban.dto.LabelResDto;
@@ -22,4 +23,7 @@ public interface LabelMapper {
 
 	@Mapping(target = "labelId", source = "label.id")
 	KanbanBoardResDto.LabelDto toKanbanDto(Label label);
+
+	@Mapping(target = "labelId", source = "label.id")
+	IssueDetailResDto.LabelDto toIssueDetailDto(Label label);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueLabelRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueLabelRepository.java
@@ -3,9 +3,18 @@ package scrumpledpaper.agiler.kanban.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import scrumpledpaper.agiler.kanban.entity.IssueLabel;
 
 public interface IssueLabelRepository extends JpaRepository<IssueLabel, Long> {
 	List<IssueLabel> findAllByIssueId(Long issueId);
+
+	@Query("""
+		SELECT il
+		FROM IssueLabel il
+		LEFT JOIN FETCH il.label
+		WHERE il.issue.id = :issueId
+	""")
+	List<IssueLabel> findAllByIssueIdWithRelationLabel(Long issueId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/repository/IssueRepository.java
@@ -39,5 +39,12 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
 		LocalDateTime startTime,
 		LocalDateTime endTime
 	);
+
+	@Query("""
+	SELECT i FROM Issue i
+		LEFT JOIN FETCH i.kanbanConfig kc
+	WHERE i.id = :issueId
+	""")
+	Optional<Issue> findByIssueIdWithRelationKanbanConfig(Long issueId);
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
@@ -17,6 +17,7 @@ import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.kanban.dto.IssueAssigneesReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDateUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueKanbanConfigUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueLabelsReqDto;
@@ -329,4 +330,34 @@ public class IssueService {
 			issue.getKanbanConfig()
 		);
 	}
+
+	@Transactional
+	public long updateIssueDate(long userId, String projectUrl, Long issueId, IssueDateUpdateReqDto request) {
+		projectValidator.validateAccess(userId, projectUrl);
+
+		Issue issue = findIssueById(issueId);
+		validateIssueDate(
+			request.startedAt().orElse(null),
+			request.dueAt().orElse(null)
+		);
+
+		issue.updateIssueDate(
+			request.startedAt().orElse(null),
+			request.dueAt().orElse(null)
+		);
+		return issue.getId();
+	}
+
+	private void validateIssueDate(LocalDateTime startedAt, LocalDateTime dueAt) {
+		if (startedAt != null && dueAt != null && startedAt.isAfter(dueAt)) {
+			throw new CustomException(ErrorCode.ISSUE_INVALID_DATE_RANGE);
+		}
+
+		LocalDate today = LocalDate.now();
+		if ((startedAt != null && !startedAt.toLocalDate().isEqual(today)) ||
+			(dueAt != null && !dueAt.toLocalDate().isEqual(today))) {
+			throw new CustomException(ErrorCode.ISSUE_DATE_MUST_TODAY);
+		}
+	}
 }
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
@@ -63,6 +63,7 @@ public class IssueService {
 		ProjectAccessContext projectAccessContext = projectValidator.validateAccess(userId, projectUrl);
 		Project project = projectAccessContext.project();
 
+		validateIssueDate(issueCreateReqDto.startedAt(), issueCreateReqDto.dueAt());
 		KanbanConfig defaultKanbanConfig = kanbanConfigService.getDefaultStatusKanbanConfig(project.getId());
 		Issue newIssue = issueRepository.save(issueMapper.toEntity(project, defaultKanbanConfig, issueCreateReqDto));
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
@@ -17,6 +17,7 @@ import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.kanban.dto.IssueAssigneesReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueKanbanConfigUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueLabelsReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueUpdateReqDto;
@@ -308,5 +309,24 @@ public class IssueService {
 			.toList();
 
 		return new KanbanBoardResDto(kanbanConfigDtos, profileDtos, labelDtos, issueDtos);
+	}
+
+	@Transactional(readOnly = true)
+	public IssueDetailResDto getIssueDetail(long userId, String projectUrl, Long issueId) {
+		ProjectAccessContext projectAccessContext = projectValidator.validateAccess(userId, projectUrl);
+		Project project = projectAccessContext.project();
+
+		Issue issue = issueRepository.findByIssueIdWithRelationKanbanConfig(issueId)
+			.orElseThrow(() -> new CustomException(ErrorCode.ISSUE_NOT_FOUND));
+		List<IssueDetailResDto.LabelDto> labelDtos = labelService.getIssueLabelsAsDetailDto(issueId);
+		List<IssueDetailResDto.AssigneeDto> assigneeDtos = profileService.getIssueAssigneesAsDetailDto(issueId);
+
+
+		return issueMapper.toIssueDetailDto(
+			issue,
+			labelDtos,
+			assigneeDtos,
+			issue.getKanbanConfig()
+		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/IssueService.java
@@ -323,7 +323,6 @@ public class IssueService {
 		List<IssueDetailResDto.LabelDto> labelDtos = labelService.getIssueLabelsAsDetailDto(issueId);
 		List<IssueDetailResDto.AssigneeDto> assigneeDtos = profileService.getIssueAssigneesAsDetailDto(issueId);
 
-
 		return issueMapper.toIssueDetailDto(
 			issue,
 			labelDtos,

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/LabelService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/service/LabelService.java
@@ -9,13 +9,16 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanBoardResDto;
 import scrumpledpaper.agiler.kanban.dto.LabelCreateReqDto;
 import scrumpledpaper.agiler.kanban.dto.LabelResDto;
 import scrumpledpaper.agiler.kanban.dto.LabelUpdateReqDto;
 import scrumpledpaper.agiler.kanban.entity.DefaultLabel;
+import scrumpledpaper.agiler.kanban.entity.IssueLabel;
 import scrumpledpaper.agiler.kanban.entity.Label;
 import scrumpledpaper.agiler.kanban.mapper.LabelMapper;
+import scrumpledpaper.agiler.kanban.repository.IssueLabelRepository;
 import scrumpledpaper.agiler.kanban.repository.LabelRepository;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Project;
@@ -26,6 +29,7 @@ import scrumpledpaper.agiler.project.service.ProjectValidator;
 public class LabelService {
 	private final LabelMapper labelMapper;
 	private final LabelRepository labelRepository;
+	private final IssueLabelRepository issueLabelRepository;
 	private final ProjectValidator projectValidator;
 
 	public void createDefaultLabels(Project project) {
@@ -83,6 +87,16 @@ public class LabelService {
 		List<Label> labels = labelRepository.findAllByProjectId(project.getId());
 		return labels.stream()
 			.map(labelMapper::toKanbanDto)
+			.toList();
+	}
+
+	public List<IssueDetailResDto.LabelDto> getIssueLabelsAsDetailDto(Long issueId) {
+		List<IssueLabel> issueLabels = issueLabelRepository.findAllByIssueIdWithRelationLabel(issueId);
+		List<Label> labels = issueLabels.stream()
+			.map(IssueLabel::getLabel)
+			.toList();
+		return labels.stream()
+			.map(labelMapper::toIssueDetailDto)
 			.toList();
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/mapper/ProfileMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/mapper/ProfileMapper.java
@@ -3,6 +3,7 @@ package scrumpledpaper.agiler.project.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanBoardResDto;
 import scrumpledpaper.agiler.project.dto.ProfileResDto;
 import scrumpledpaper.agiler.project.entity.Profile;
@@ -26,6 +27,17 @@ public interface ProfileMapper {
 
 	default KanbanBoardResDto.ProfileDto toKanbanProfileDto(Profile profile, String imageUrl) {
 		return new KanbanBoardResDto.ProfileDto(
+			profile.getId(),
+			profile.getNickname(),
+			profile.getEmail(),
+			imageUrl,
+			profile.getRole().name(),
+			profile.getDescription()
+		);
+	}
+
+	default IssueDetailResDto.AssigneeDto toIssueAssigneeDto(Profile profile, String imageUrl) {
+		return new IssueDetailResDto.AssigneeDto(
 			profile.getId(),
 			profile.getNickname(),
 			profile.getEmail(),

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/repository/ProfileRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/repository/ProfileRepository.java
@@ -6,7 +6,9 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import scrumpledpaper.agiler.kanban.entity.IssueProfile;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Role;
 
@@ -22,4 +24,12 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 	long countByProjectIdAndRoleAndIdNot(Long projectId, Role role, Long excludeProfileId);
 	List<Profile> findByProjectIdAndIdIn(Long projectId, List<Long> profileIds);
 	List<Profile> findAllByProjectId(Long projectId);
+
+	@Query("""
+		SELECT ip
+		FROM IssueProfile ip
+		LEFT JOIN FETCH ip.profile
+		WHERE ip.issue.id = :issueId
+	""")
+	List<IssueProfile> findIssueProfilesByIssueIdWithRelationProfile(Long issueId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProfileService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProfileService.java
@@ -15,7 +15,9 @@ import scrumpledpaper.agiler.common.PageValidator;
 import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.KanbanBoardResDto;
+import scrumpledpaper.agiler.kanban.entity.IssueProfile;
 import scrumpledpaper.agiler.project.dto.ProfileResDto;
 import scrumpledpaper.agiler.project.dto.ProfileUpdateReqDto;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
@@ -159,6 +161,30 @@ public class ProfileService {
 					.orElse("");
 
 				return profileMapper.toKanbanProfileDto(profile, imageUrl);
+			})
+			.toList();
+	}
+
+	public List<IssueDetailResDto.AssigneeDto> getIssueAssigneesAsDetailDto(Long issueId) {
+		List<IssueProfile> issueProfiles = profileRepository.findIssueProfilesByIssueIdWithRelationProfile(issueId);
+		List<Profile> profiles = issueProfiles.stream()
+			.map(IssueProfile::getProfile)
+			.toList();
+
+		List<Long> imageIds = profiles.stream()
+			.map(Profile::getImageId)
+			.distinct()
+			.toList();
+
+		Map<Long, String> imageUrlMap = imageService.getImageUrlsByIds(imageIds);
+
+		return issueProfiles.stream()
+			.map(ip -> {
+				Profile profile = ip.getProfile();
+				String imageUrl = Optional.ofNullable(profile.getImageId())
+					.map(imageUrlMap::get)
+					.orElse("");
+				return profileMapper.toIssueAssigneeDto(profile, imageUrl);
 			})
 			.toList();
 	}

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
@@ -31,6 +31,7 @@ import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.kanban.dto.IssueAssigneesReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDeleteReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueKanbanConfigUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueLabelsReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueUpdateReqDto;
@@ -1296,6 +1297,113 @@ public class IssueControllerTest {
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("Get Issue Detail Test")
+	class GetIssueDetailTest {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - 이슈 상세 조회 성공")
+		public void getIssueDetailSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			KanbanConfig kanbanConfig = testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+			Issue issue = testDataFactory.createIssue(
+				project,
+				kanbanConfig,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				false,
+				null,
+				null
+			);
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/issues/{issueId}", url, issue.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			IssueDetailResDto result = objectMapper.readValue(response, IssueDetailResDto.class);
+			assertThat(result.issueId()).isEqualTo(issue.getId());
+			assertThat(result.title()).isEqualTo(issue.getTitle());
+			assertThat(result.contents()).isEqualTo(issue.getContents());
+			assertThat(result.kanbanConfig().kanbanConfigId()).isEqualTo(kanbanConfig.getId());
+			assertThat(result.isDone()).isEqualTo(issue.getIsDone());
+		}
+
+		@Test
+		@DisplayName("403 - 프로젝트 멤버가 아닌 사용자가 이슈 상세 조회 요청")
+		public void getIssueDetailForbiddenNotProjectMember() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, ownerAuth.getUser());
+			KanbanConfig kanbanConfig = testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+			Issue issue = testDataFactory.createIssue(
+				project,
+				kanbanConfig,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				false,
+				null,
+				null
+			);
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/issues/{issueId}", url, issue.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 이슈 상세 조회 요청")
+		public void getIssueDetailNotFoundIssue() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/issues/{issueId}", url, 9999L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_NOT_FOUND.getMessage());
 		}
 	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
@@ -113,7 +113,8 @@ public class IssueControllerTest {
 			assertThat(createdIssue.getTitle()).isEqualTo(createReqDto.title());
 			assertThat(createdIssue.getContents()).isEqualTo(createReqDto.contents());
 
-			KanbanConfig createdKanbanConfig = testDataFactory.findKanbanConfigById(createdIssue.getKanbanConfig().getId());
+			KanbanConfig createdKanbanConfig = testDataFactory.findKanbanConfigById(
+				createdIssue.getKanbanConfig().getId());
 			assertThat(createdKanbanConfig.getId()).isEqualTo(defaultKanbanConfig.getId());
 
 			List<IssueLabel> createdIssueLabels = testDataFactory.findIssueLabelsByIssueId(createdIssue.getId());
@@ -140,7 +141,8 @@ public class IssueControllerTest {
 					tuple(createdIssue.getId(), assigneeProfile.getId())
 				);
 
-			IssueSnapshotDateMapping updatedMapping = testDataFactory.findIssueSnapshotDateMapping(project, LocalDate.now());
+			IssueSnapshotDateMapping updatedMapping = testDataFactory.findIssueSnapshotDateMapping(project,
+				LocalDate.now());
 			assertThat(updatedMapping.getIssueCount()).isEqualTo(issueCount + 1);
 		}
 
@@ -175,7 +177,8 @@ public class IssueControllerTest {
 			assertThat(createdIssue.getTitle()).isEqualTo(createReqDto.title());
 			assertThat(createdIssue.getContents()).isEqualTo(createReqDto.contents());
 
-			KanbanConfig createdKanbanConfig = testDataFactory.findKanbanConfigById(createdIssue.getKanbanConfig().getId());
+			KanbanConfig createdKanbanConfig = testDataFactory.findKanbanConfigById(
+				createdIssue.getKanbanConfig().getId());
 			assertThat(createdKanbanConfig.getId()).isEqualTo(defaultKanbanConfig.getId());
 
 			List<IssueLabel> createdIssueLabels = testDataFactory.findIssueLabelsByIssueId(createdIssue.getId());
@@ -184,7 +187,6 @@ public class IssueControllerTest {
 			List<IssueProfile> createdIssueProfiles = testDataFactory.findIssueProfilesByIssueId(createdIssue.getId());
 			assertThat(createdIssueProfiles).isEmpty();
 		}
-
 
 		@Test
 		@DisplayName("201 - 이슈 생성 성공 - Assignees가 여러명이며, 이 중 프로젝트 멤버가 아닌 사용자가 포함된 경우")
@@ -196,7 +198,8 @@ public class IssueControllerTest {
 			String url = "test-url";
 			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
 			Profile assigneeProfile = testDataFactory.createProfile(assigneeAuth.getUser(), project, Role.MEMBER);
-			Profile anotherMemberProfile = testDataFactory.createProfile(anotherMemberAuth.getUser(), project, Role.MEMBER);
+			Profile anotherMemberProfile = testDataFactory.createProfile(anotherMemberAuth.getUser(), project,
+				Role.MEMBER);
 			KanbanConfig defaultKanbanConfig = testDataFactory.createKanbanConfig(project, 1, true, false, false);
 			Label label1 = testDataFactory.createLabel(project, "label1", "label1 description", "#FF0000");
 			Label label2 = testDataFactory.createLabel(project, "label2", "label2 description", "#00FF00");
@@ -221,7 +224,8 @@ public class IssueControllerTest {
 			assertThat(createdIssue.getTitle()).isEqualTo(createReqDto.title());
 			assertThat(createdIssue.getContents()).isEqualTo(createReqDto.contents());
 
-			KanbanConfig createdKanbanConfig = testDataFactory.findKanbanConfigById(createdIssue.getKanbanConfig().getId());
+			KanbanConfig createdKanbanConfig = testDataFactory.findKanbanConfigById(
+				createdIssue.getKanbanConfig().getId());
 			assertThat(createdKanbanConfig.getId()).isEqualTo(defaultKanbanConfig.getId());
 
 			List<IssueLabel> createdIssueLabels = testDataFactory.findIssueLabelsByIssueId(createdIssue.getId());
@@ -561,7 +565,7 @@ public class IssueControllerTest {
 				randomString(50),
 				null,
 				null
-				);
+			);
 
 			// when
 			String response = mockMvc.perform(
@@ -1426,6 +1430,7 @@ public class IssueControllerTest {
 			AuthContext auth = testDataFactory.createAuth(defaultImage);
 			String url = "test-url";
 			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile profile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
 			KanbanConfig kanbanConfig = testDataFactory.createKanbanConfig(
 				project,
 				1,
@@ -1433,11 +1438,12 @@ public class IssueControllerTest {
 				false,
 				false
 			);
+			Label label1 = testDataFactory.createLabel(project, "label1", "label1 description", "#FF0000");
 			Issue issue = testDataFactory.createIssue(
 				project,
 				kanbanConfig,
-				Collections.emptyList(),
-				Collections.emptyList(),
+				List.of(profile),
+				List.of(label1),
 				false,
 				null,
 				null
@@ -1458,6 +1464,23 @@ public class IssueControllerTest {
 			assertThat(result.contents()).isEqualTo(issue.getContents());
 			assertThat(result.kanbanConfig().kanbanConfigId()).isEqualTo(kanbanConfig.getId());
 			assertThat(result.isDone()).isEqualTo(issue.getIsDone());
+			assertThat(result.assignees())
+				.hasSize(1)
+				.first()
+				.satisfies(a -> {
+					assertThat(a.profileId()).isEqualTo(profile.getId());
+					assertThat(a.nickname()).isEqualTo(profile.getNickname());
+					assertThat(a.email()).isEqualTo(profile.getEmail());
+				});
+			assertThat(result.labels())
+				.hasSize(1)
+				.first()
+				.satisfies(l -> {
+					assertThat(l.labelId()).isEqualTo(label1.getId());
+					assertThat(l.name()).isEqualTo(label1.getName());
+					assertThat(l.description()).isEqualTo(label1.getDescription());
+					assertThat(l.color()).isEqualTo(label1.getColor());
+				});
 		}
 
 		@Test

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
@@ -2,6 +2,7 @@ package scrumpledpaper.agiler.kanban;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static scrumpledpaper.agiler.common.TestDataFactory.*;
 
@@ -9,11 +10,16 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +36,7 @@ import scrumpledpaper.agiler.fixture.IssueFixture;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.kanban.dto.IssueAssigneesReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueCreateReqDto;
+import scrumpledpaper.agiler.kanban.dto.IssueDateUpdateReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDeleteReqDto;
 import scrumpledpaper.agiler.kanban.dto.IssueDetailResDto;
 import scrumpledpaper.agiler.kanban.dto.IssueKanbanConfigUpdateReqDto;
@@ -1404,6 +1411,296 @@ public class IssueControllerTest {
 
 			// then
 			assertThat(response).contains(ErrorCode.ISSUE_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("Update Issue Date Test")
+	class UpdateIssueDateTest {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@ParameterizedTest
+		@MethodSource("provideDateUpdateCases")
+		@DisplayName("200 - 이슈 시작시간, 종료시간 수정 성공")
+		public void issueUpdateDateSuccess(
+			Optional<LocalDateTime> startedAt,
+			Optional<LocalDateTime> dueAt
+		) throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			KanbanConfig defaultKanbanConfig = testDataFactory.createKanbanConfig(
+				project, 1, true, false, false
+			);
+			Issue issue = testDataFactory.createIssue(
+				project,
+				defaultKanbanConfig,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				false,
+				null,
+				null
+			);
+
+			IssueDateUpdateReqDto updateDateReqDto = new IssueDateUpdateReqDto(startedAt, dueAt);
+
+			// when
+			String response = mockMvc.perform(
+				patch("/api/v1/projects/{projectUrl}/issues/{issueId}/date", url, issue.getId())
+					.cookie(new Cookie("accessToken", auth.getToken()))
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(updateDateReqDto)))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// 검증
+			Issue updatedIssue = testDataFactory.findIssueById(issue.getId()).get();
+			assertThat(response).contains(issue.getId().toString());
+			assertThat(updatedIssue.getStartedAt()).isEqualTo(startedAt.orElse(null));
+			assertThat(updatedIssue.getDueAt()).isEqualTo(dueAt.orElse(null));
+		}
+
+		private static Stream<Arguments> provideDateUpdateCases() {
+			LocalDate today = LocalDate.now();
+			LocalDateTime historical = today.atTime(10, 0, 0);
+			LocalDateTime future = today.atTime(18, 0, 0);
+
+			return Stream.of(
+				Arguments.of(Optional.of(historical), Optional.of(future), "둘 다 있음"),
+				Arguments.of(Optional.of(historical), Optional.empty(), "시작일만 있음"),
+				Arguments.of(Optional.empty(), Optional.of(future), "종료일만 있음"),
+				Arguments.of(Optional.empty(), Optional.empty(), "둘 다 없음")
+			);
+		}
+
+		@Test
+		@DisplayName("403 - 프로젝트 멤버가 아닌 사용자가 이슈 시작시간, 종료시간 수정 요청")
+		public void issueUpdateDateForbiddenNotProjectMember() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext ownerAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, ownerAuth.getUser());
+			KanbanConfig defaultKanbanConfig = testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+			Issue issue = testDataFactory.createIssue(
+				project,
+				defaultKanbanConfig,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				false,
+				null,
+				null
+			);
+
+			LocalDate today = LocalDate.now();
+			LocalDateTime historical = today.atTime(10, 0, 0);
+			LocalDateTime future = today.atTime(18, 0, 0);
+
+			IssueDateUpdateReqDto updateDateReqDto = new IssueDateUpdateReqDto(
+				Optional.of(historical),
+				Optional.of(future)
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/issues/{issueId}/date", url, issue.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(updateDateReqDto)))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 이슈의 ID로 시작시간, 종료시간 수정 요청")
+		public void issueUpdateDateNotFoundIssue() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			KanbanConfig defaultKanbanConfig = testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+
+			LocalDate today = LocalDate.now();
+			LocalDateTime historical = today.atTime(10, 0, 0);
+			LocalDateTime future = today.atTime(18, 0, 0);
+
+			IssueDateUpdateReqDto updateDateReqDto = new IssueDateUpdateReqDto(
+				Optional.of(historical),
+				Optional.of(future)
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/issues/{issueId}/date", url, 9999L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(updateDateReqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트에 이슈 시작시간, 종료시간 수정 요청")
+		public void issueUpdateDateNotFoundProject() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+
+			LocalDate today = LocalDate.now();
+			LocalDateTime historical = today.atTime(10, 0, 0);
+			LocalDateTime future = today.atTime(18, 0, 0);
+
+			IssueDateUpdateReqDto updateDateReqDto = new IssueDateUpdateReqDto(
+				Optional.of(historical),
+				Optional.of(future)
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/issues/{issueId}/date", "not_exist_url", 9999L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(updateDateReqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("400 - 종료시간이 시작시간보다 이전인 경우")
+		public void issueUpdateDateBadRequestDueAtBeforeStartedAt() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			KanbanConfig defaultKanbanConfig = testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+			Issue issue = testDataFactory.createIssue(
+				project,
+				defaultKanbanConfig,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				false,
+				null,
+				null
+			);
+
+			LocalDate today = LocalDate.now();
+			LocalDateTime historical = today.atTime(10, 0, 0);
+			LocalDateTime future = today.atTime(9, 0, 0);
+
+			IssueDateUpdateReqDto updateDateReqDto = new IssueDateUpdateReqDto(
+				Optional.of(historical),
+				Optional.of(future)
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/issues/{issueId}/date", url, issue.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(updateDateReqDto)))
+				.andExpect(status().isBadRequest())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_INVALID_DATE_RANGE.getMessage());
+		}
+
+		@ParameterizedTest
+		@MethodSource("provideDateUpdateInvalidCases")
+		@DisplayName("400 - 시작시간이나 종료시간이 당일이 아닌 경우")
+		public void issueUpdateDateBadRequestNotToday(
+			Optional<LocalDateTime> startedAt,
+			Optional<LocalDateTime> dueAt
+		) throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			KanbanConfig defaultKanbanConfig = testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+			Issue issue = testDataFactory.createIssue(
+				project,
+				defaultKanbanConfig,
+				Collections.emptyList(),
+				Collections.emptyList(),
+				false,
+				null,
+				null
+			);
+
+			IssueDateUpdateReqDto updateDateReqDto = new IssueDateUpdateReqDto(startedAt, dueAt);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/issues/{issueId}/date", url, issue.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(updateDateReqDto)))
+				.andExpect(status().isBadRequest())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_DATE_MUST_TODAY.getMessage());
+		}
+
+		private static Stream<Arguments> provideDateUpdateInvalidCases() {
+			LocalDate today = LocalDate.now();
+			LocalDate yesterday = today.minusDays(1);
+			LocalDate tomorrow = today.plusDays(1);
+
+			LocalDateTime todayMorning = today.atTime(10, 0, 0);
+			LocalDateTime todayEvening = today.atTime(18, 0, 0);
+			LocalDateTime yesterdayDateTime = yesterday.atTime(10, 0, 0);
+			LocalDateTime tomorrowDateTime = tomorrow.atTime(18, 0, 0);
+
+			return Stream.of(
+				// 과거 날짜
+				Arguments.of(Optional.of(yesterdayDateTime), Optional.of(todayEvening), "시작일이 과거"),
+				Arguments.of(Optional.of(yesterdayDateTime), Optional.of(yesterdayDateTime), "둘 다 과거"),
+
+				// 미래 날짜
+				Arguments.of(Optional.of(todayMorning), Optional.of(tomorrowDateTime), "종료일이 미래"),
+				Arguments.of(Optional.of(tomorrowDateTime), Optional.of(tomorrowDateTime), "둘 다 미래"),
+
+				// 과거와 미래 혼합
+				Arguments.of(Optional.of(yesterdayDateTime), Optional.of(tomorrowDateTime), "시작일 과거, 종료일 미래")
+			);
 		}
 	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
@@ -253,6 +253,110 @@ public class IssueControllerTest {
 		}
 
 		@Test
+		@DisplayName("400 - 시작시간이 종료시간보다 이후인 이슈 생성 요청")
+		public void issueCreateBadRequestStartAfterDue() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+
+			LocalDate today = LocalDate.now();
+			LocalDateTime historical = today.atTime(10, 0, 0);
+			LocalDateTime future = today.atTime(9, 0, 0);
+
+			IssueCreateReqDto createReqDto = IssueFixture.createIssueCreateReqDto(
+				Collections.emptyList(),
+				Collections.emptyList(),
+				historical,
+				future
+			);
+			String updateJson = objectMapper.writeValueAsString(createReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					post("/api/v1/projects/{projectUrl}/issues", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isBadRequest())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_INVALID_DATE_RANGE.getMessage());
+		}
+
+		@ParameterizedTest
+		@MethodSource("provideDateCreateInvalidCases")
+		@DisplayName("400 - 시작시간이나 종료시간이 당일이 아닌 경우")
+		public void issueUpdateDateBadRequestNotToday(
+			Optional<LocalDateTime> startedAt,
+			Optional<LocalDateTime> dueAt
+		) throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			testDataFactory.createKanbanConfig(
+				project,
+				1,
+				true,
+				false,
+				false
+			);
+
+			IssueCreateReqDto createReqDto = IssueFixture.createIssueCreateReqDto(
+				Collections.emptyList(),
+				Collections.emptyList(),
+				startedAt.orElse(null),
+				dueAt.orElse(null)
+			);
+			String updateJson = objectMapper.writeValueAsString(createReqDto);
+
+			// when
+			String response = mockMvc.perform(
+					post("/api/v1/projects/{projectUrl}/issues", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(updateJson))
+				.andExpect(status().isBadRequest())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.ISSUE_DATE_MUST_TODAY.getMessage());
+		}
+
+		private static Stream<Arguments> provideDateCreateInvalidCases() {
+			LocalDate today = LocalDate.now();
+			LocalDate yesterday = today.minusDays(1);
+			LocalDate tomorrow = today.plusDays(1);
+
+			LocalDateTime todayMorning = today.atTime(10, 0, 0);
+			LocalDateTime todayEvening = today.atTime(18, 0, 0);
+			LocalDateTime yesterdayDateTime = yesterday.atTime(10, 0, 0);
+			LocalDateTime tomorrowDateTime = tomorrow.atTime(18, 0, 0);
+
+			return Stream.of(
+				// 과거 날짜
+				Arguments.of(Optional.of(yesterdayDateTime), Optional.of(todayEvening), "시작일이 과거"),
+				Arguments.of(Optional.of(yesterdayDateTime), Optional.of(yesterdayDateTime), "둘 다 과거"),
+
+				// 미래 날짜
+				Arguments.of(Optional.of(todayMorning), Optional.of(tomorrowDateTime), "종료일이 미래"),
+				Arguments.of(Optional.of(tomorrowDateTime), Optional.of(tomorrowDateTime), "둘 다 미래"),
+
+				// 과거와 미래 혼합
+				Arguments.of(Optional.of(yesterdayDateTime), Optional.of(tomorrowDateTime), "시작일 과거, 종료일 미래")
+			);
+		}
+
+		@Test
 		@DisplayName("404 - 존재하지 않는 프로젝트에 이슈 생성 요청")
 		public void issueCreateNotFoundProject() throws Exception {
 			// given


### PR DESCRIPTION
## 🚀 기능 개요

이슈 단일 상세조회, 이슈 시작시간, 종료시간 수정 API를 작성했습니다.

## 🧩 작업 사항

- Issue 상세 조회 API 작성
- Issue 상세 조회 API 테스트 코드 작성
- Issue 시작/종료 시간 수정 API 작성
- Issue 시작/종료 시간 수정 API 테스트 코드 작성

## 🔄 변경 로직

- 이슈 생성시 StartedAt, DueAt 검증로직 추가

## 🗂️ 이슈 번호
- #108 
- #116 