### PR TITLE
[Bug] 🐛 테스트 실행 시 Note 리스트 조회가 간헐적으로 실패하는 버그

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
@@ -1,5 +1,6 @@
 package scrumpledpaper.agiler.note.service;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ public class MeetingService {
 			.stream()
 			.collect(Collectors.groupingBy(
 				mp -> mp.getMeeting().getId(),
+				LinkedHashMap::new,
 				Collectors.mapping(MeetingProfile::getProfile, Collectors.toList())
 			));
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
@@ -1,5 +1,6 @@
 package scrumpledpaper.agiler.note.service;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ public class RetroService {
 			.stream()
 			.collect(Collectors.groupingBy(
 				retroProfile -> retroProfile.getRetro().getId(),
+				LinkedHashMap::new,
 				Collectors.mapping(RetroProfile::getProfile, Collectors.toList())
 			));
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/ScrumService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/ScrumService.java
@@ -1,5 +1,6 @@
 package scrumpledpaper.agiler.note.service;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -70,6 +71,7 @@ public class ScrumService {
 			.stream()
 			.collect(Collectors.groupingBy(
 				scrumProfile -> scrumProfile.getScrum().getId(),
+				LinkedHashMap::new,
 				Collectors.mapping(ScrumProfile::getProfile, Collectors.toList())
 			));
 

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
@@ -481,7 +481,11 @@ public class TestDataFactory {
 	}
 
 	public Page<Meeting> findMeetingsByProjectIdPaged(Long id, int page, int size) {
-		Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
+		Pageable pageable = PageRequest.of(
+			page, size,
+			Sort.by("id").ascending()
+				.and(Sort.by("createdAt").ascending())
+		);
 		return meetingRepository.findAllByProjectId(id, pageable);
 	}
 
@@ -499,7 +503,11 @@ public class TestDataFactory {
 	}
 
 	public Page<Retro> findRetrosByProjectIdPaged(Long id, int page, int size) {
-		Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
+		Pageable pageable = PageRequest.of(
+			page, size,
+			Sort.by("id").ascending()
+				.and(Sort.by("createdAt").ascending())
+		);
 		return retroRepository.findAllByProjectId(id, pageable);
 	}
 
@@ -532,7 +540,11 @@ public class TestDataFactory {
 	}
 
 	public Page<Scrum> findScrumsByProjectIdPaged(Long id, int page, int size) {
-		Pageable pageable = PageRequest.of(page, size, Sort.by("id").ascending());
+		Pageable pageable = PageRequest.of(
+			page, size,
+			Sort.by("id").ascending()
+				.and(Sort.by("createdAt").ascending())
+		);
 		return scrumRepository.findAllByProjectId(id, pageable);
 	}
 


### PR DESCRIPTION
## 🚀 기능 개요

검증로직의 Page에서 순서보장이 안되는것이 문제가 아닌, Collectors.groupingBy()에서 내부적으로 HashMap을 사용하여 순서가 보장되어지지 않았습니다.

## 🧩 작업 사항

- Note 관련 Service 로직에 LinkedHashMap 추가
- TestDataFactory의 Page 조회시 id 및 createdAt Dto와 동일하게 수정

## 🗂️ 이슈 번호
-closed #120 