### PR TITLE
[BE] ✨ Wss Token API 및 Internal API, Note Participants Update API 구현

### DIFF
--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/ApiKeyAuthFilter.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/ApiKeyAuthFilter.java
@@ -1,9 +1,14 @@
 package scrumpledpaper.agiler.auth.filter;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -14,16 +19,25 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @Component
 public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
 	@Value("${app.api.key}")
 	private String expectedKey;
+	private static final String INTERNAL_API_ROLE = "ROLE_INTERNAL";
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
 		throws ServletException, IOException {
+
 		String path = request.getRequestURI();
 		if (path.startsWith("/internal/")) {
 			String key = request.getHeader("X-API-KEY");
 			if (expectedKey.equals(key)) {
+				Authentication authentication = new PreAuthenticatedAuthenticationToken(
+					key,
+					null,
+					List.of(new SimpleGrantedAuthority(INTERNAL_API_ROLE))
+				);
+				SecurityContextHolder.getContext().setAuthentication(authentication);
 				filterChain.doFilter(request, response);
 			} else {
 				response.setStatus(HttpStatus.UNAUTHORIZED.value());

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/ApiKeyAuthFilter.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/auth/filter/ApiKeyAuthFilter.java
@@ -1,0 +1,36 @@
+package scrumpledpaper.agiler.auth.filter;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+	@Value("${app.api.key}")
+	private String expectedKey;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+		throws ServletException, IOException {
+		String path = request.getRequestURI();
+		if (path.startsWith("/internal/")) {
+			String key = request.getHeader("X-API-KEY");
+			if (expectedKey.equals(key)) {
+				filterChain.doFilter(request, response);
+			} else {
+				response.setStatus(HttpStatus.UNAUTHORIZED.value());
+				response.getWriter().write("Invalid API Key");
+			}
+		} else {
+			filterChain.doFilter(request, response);
+		}
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/AppProperties.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/AppProperties.java
@@ -15,6 +15,7 @@ public class AppProperties {
 
 	private final Auth auth = new Auth();
 	private final OAuth2 oauth2 = new OAuth2();
+	private final Api api = new Api();
 
 	@Getter
 	@Setter
@@ -29,5 +30,12 @@ public class AppProperties {
 	@Setter
 	public static final class OAuth2 {
 		private List<String> authorizedRedirectUris = new ArrayList<>();
+	}
+
+	@Getter
+	@Setter
+	public static class Api {
+		private String key;
+		private long wssTokenExpiry;
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/config/SecurityConfig.java
@@ -3,12 +3,15 @@ package scrumpledpaper.agiler.common.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import scrumpledpaper.agiler.auth.filter.ApiKeyAuthFilter;
 import scrumpledpaper.agiler.auth.filter.JwtAuthenticationFilter;
 import scrumpledpaper.agiler.auth.handler.CustomAccessDeniedHandler;
 import scrumpledpaper.agiler.auth.handler.CustomAuthenticationEntryPoint;
@@ -22,6 +25,7 @@ import scrumpledpaper.agiler.auth.service.CustomOAuth2UserService;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+	private final ApiKeyAuthFilter apiKeyAuthFilter;
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 	private final CustomAccessDeniedHandler customAccessDeniedHandler;
@@ -30,6 +34,7 @@ public class SecurityConfig {
 	private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 	private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
+	private static final String INTERNAL_API_ROLE = "ROLE_INTERNAL";
 	private static final String[] PERMIT_URL_ARRAY = {
 			/* swagger */
 			"/v3/api-docs/**",
@@ -41,37 +46,59 @@ public class SecurityConfig {
 	};
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	@Order(1)
+	public SecurityFilterChain internalSecurityFilterChain(HttpSecurity http) throws Exception {
 		http
-				.csrf(AbstractHttpConfigurer::disable)
-				.formLogin(AbstractHttpConfigurer::disable)
-				.httpBasic(AbstractHttpConfigurer::disable)
-				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-				.exceptionHandling(exception -> exception
-						.authenticationEntryPoint(customAuthenticationEntryPoint)
-						.accessDeniedHandler(customAccessDeniedHandler)
-				)
-				.authorizeHttpRequests(auth -> auth
-						.requestMatchers(PERMIT_URL_ARRAY).permitAll()
-						.anyRequest().authenticated()
-				)
-				.oauth2Login(oauth2 -> oauth2
-						.authorizationEndpoint(auth -> auth
-								.baseUri("/api/oauth2/authorization")
-								.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
-						)
-						.redirectionEndpoint(redirect -> redirect
-								.baseUri("/api/login/oauth2/code/*")
-						)
-						.userInfoEndpoint(userInfo -> userInfo
-								.userService(customOAuth2UserService)
-						)
-						.successHandler(oAuth2AuthenticationSuccessHandler)
-						.failureHandler(oAuth2AuthenticationFailureHandler)
-				)
-				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.securityMatcher("/internal/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(customAuthenticationEntryPoint)
+				.accessDeniedHandler(customAccessDeniedHandler)
+			)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/internal/**").hasAuthority(INTERNAL_API_ROLE)
+				.anyRequest().authenticated()
+			)
+			.addFilterBefore(apiKeyAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}
+	@Bean
+	@Order(2)
+	public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher(request -> !request.getRequestURI().startsWith("/internal/"))
+			.csrf(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(customAuthenticationEntryPoint)
+				.accessDeniedHandler(customAccessDeniedHandler)
+			)
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers(PERMIT_URL_ARRAY).permitAll()
+				.anyRequest().authenticated()
+			)
+			.oauth2Login(oauth2 -> oauth2
+				.authorizationEndpoint(auth -> auth
+					.baseUri("/api/oauth2/authorization")
+					.authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)
+				)
+				.redirectionEndpoint(redirect -> redirect
+					.baseUri("/api/login/oauth2/code/*")
+				)
+				.userInfoEndpoint(userInfo -> userInfo
+					.userService(customOAuth2UserService)
+				)
+				.successHandler(oAuth2AuthenticationSuccessHandler)
+				.failureHandler(oAuth2AuthenticationFailureHandler)
+			)
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
+		return http.build();
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/exception/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 	MEETING_TEMPLATE_NOT_FOUND(404, "T004", "회의 템플릿을 찾을 수 없습니다."),
 
 	NOTE_NOT_FOUND(404, "NT001", "문서를 찾을 수 없습니다."),
+	INVALID_DOCUMENT_ID(400, "NT002", "유효하지 않은 문서 ID입니다."),
 
 	DEFAULT_KANBAN_CONFIG_NOT_FOUND(404, "K001", "Default 칸반 설정을 찾을 수 없습니다."),
 	KANBAN_CONFIG_NOT_FOUND(404, "K002", "칸반 설정을 찾을 수 없습니다."),

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/CookieUtils.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/CookieUtils.java
@@ -1,13 +1,14 @@
 package scrumpledpaper.agiler.common.utils;
 
-import jakarta.servlet.http.Cookie;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
 import org.springframework.http.ResponseCookie;
 import org.springframework.util.SerializationUtils;
 
-import java.util.Base64;
-import java.util.Optional;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class CookieUtils {
 
@@ -56,15 +57,5 @@ public class CookieUtils {
 	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
 		return cls.cast(SerializationUtils.deserialize(
 				Base64.getUrlDecoder().decode(cookie.getValue())));
-	}
-
-	public static void addProjectUrlCookie(HttpServletResponse response, String projectUrl, long maxAgeSeconds) {
-		ResponseCookie cookie = ResponseCookie.from("project_url", projectUrl)
-			.path("/")
-			.httpOnly(true)
-			.maxAge(maxAgeSeconds)
-			.sameSite("Lax")
-			.build();
-		response.addHeader("Set-Cookie", cookie.toString());
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/WssTokenProvider.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/WssTokenProvider.java
@@ -1,20 +1,31 @@
 package scrumpledpaper.agiler.common.utils;
 
+import static scrumpledpaper.agiler.common.exception.ErrorCode.*;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
+import javax.crypto.SecretKey;
+
 import org.springframework.stereotype.Component;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import scrumpledpaper.agiler.common.config.AppProperties;
+import scrumpledpaper.agiler.common.exception.CustomException;
 
 @Component
 public class WssTokenProvider {
 	private final AppProperties appProperties;
+	private final SecretKey key;
 
 	public WssTokenProvider(AppProperties appProperties) {
 		this.appProperties = appProperties;
+		this.key = Keys.hmacShaKeyFor(appProperties.getApi().getKey().getBytes(StandardCharsets.UTF_8));
 	}
 
 	public String createWssToken(Long userId, String docId) {
@@ -26,8 +37,22 @@ public class WssTokenProvider {
 			.claim("docId", docId)
 			.issuedAt(now)
 			.expiration(expiryDate)
-			.signWith(Keys.hmacShaKeyFor(appProperties.getAuth().getTokenSecret().getBytes(StandardCharsets.UTF_8)))
+			.signWith(Keys.hmacShaKeyFor(appProperties.getApi().getKey().getBytes(StandardCharsets.UTF_8)))
 			.compact();
+	}
+
+	public Claims getClaims(String token) {
+		try {
+			return Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token)
+				.getPayload();
+		} catch (SecurityException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+			throw new CustomException(INVALID_TOKEN);
+		} catch (ExpiredJwtException e) {
+			throw new CustomException(EXPIRED_TOKEN);
+		}
 	}
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/WssTokenProvider.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/common/utils/WssTokenProvider.java
@@ -1,0 +1,33 @@
+package scrumpledpaper.agiler.common.utils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import scrumpledpaper.agiler.common.config.AppProperties;
+
+@Component
+public class WssTokenProvider {
+	private final AppProperties appProperties;
+
+	public WssTokenProvider(AppProperties appProperties) {
+		this.appProperties = appProperties;
+	}
+
+	public String createWssToken(Long userId, String docId) {
+		Date now = new Date();
+		Date expiryDate = new Date(now.getTime() + appProperties.getApi().getWssTokenExpiry());
+
+		return Jwts.builder()
+			.subject(userId.toString())
+			.claim("docId", docId)
+			.issuedAt(now)
+			.expiration(expiryDate)
+			.signWith(Keys.hmacShaKeyFor(appProperties.getAuth().getTokenSecret().getBytes(StandardCharsets.UTF_8)))
+			.compact();
+	}
+}
+

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/controller/SnapshotController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/controller/SnapshotController.java
@@ -32,8 +32,9 @@ public class SnapshotController {
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@PathVariable String projectUrl,
 		HttpServletResponse response) {
-		long time = issueService.issueSnapshotAndResetForToday(customUserDetails.getUserId(), projectUrl);
-		CookieUtils.addProjectUrlCookie(response, projectUrl, time);
+		long timeInMillis = issueService.issueSnapshotAndResetForToday(customUserDetails.getUserId(), projectUrl);
+		long maxAgeInSeconds = timeInMillis / 1000;
+		CookieUtils.addCookie(response, projectUrl, String.valueOf(timeInMillis), (int) maxAgeInSeconds);
 		return ResponseEntity.ok().build();
 	}
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/dto/IssueUpdateReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/kanban/dto/IssueUpdateReqDto.java
@@ -12,7 +12,5 @@ public record IssueUpdateReqDto(
 	@NotBlank(message = "이슈 제목은 필수입니다.")
 	@Size(max = 20, message = "이슈 제목은 20자 이하여야 합니다.")
 	String title,
-	String contents,
-	LocalDateTime startedAt,
-	LocalDateTime dueAt
+	String contents
 ) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/MeetingController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/MeetingController.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,6 +23,8 @@ import scrumpledpaper.agiler.note.dto.IdResDto;
 import scrumpledpaper.agiler.note.dto.MeetingResDto;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.service.MeetingService;
 
 @RestController
@@ -59,5 +62,16 @@ public class MeetingController {
 		@RequestBody @Valid NoteDeleteReqDto noteDeleteReqDto) {
 		meetingService.deleteMeetings(customUserDetails.getUserId(), projectUrl, noteDeleteReqDto);
 		return ResponseEntity.noContent().build();
+	}
+
+	@PatchMapping("/{projectUrl}/meetings/{meetingId}")
+	public ResponseEntity<NoteParticipantResDto> updateMeetingParticipants(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable long meetingId,
+		@RequestBody @Valid NoteParticipantUpdateReqDto request) {
+		NoteParticipantResDto resDto = meetingService.updateMeetingParticipants(customUserDetails.getUserId(), projectUrl, meetingId, request);
+		return ResponseEntity.ok().body(resDto);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/RetroController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/RetroController.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,8 @@ import scrumpledpaper.agiler.common.PageResDto;
 import scrumpledpaper.agiler.note.dto.IdResDto;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.dto.RetroResDto;
 import scrumpledpaper.agiler.note.service.RetroService;
 
@@ -59,6 +62,17 @@ public class RetroController {
 		@RequestBody @Valid NoteDeleteReqDto request) {
 		retroService.deleteRetrospect(customUserDetails.getUserId(), projectUrl, request);
 		return ResponseEntity.noContent().build();
+	}
+
+	@PatchMapping("/{projectUrl}/retros/{retroId}")
+	public ResponseEntity<NoteParticipantResDto> updateRetroParticipants(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable long retroId,
+		@RequestBody @Valid NoteParticipantUpdateReqDto request) {
+		NoteParticipantResDto resDto = retroService.updateRetroParticipants(customUserDetails.getUserId(), projectUrl, retroId, request);
+		return ResponseEntity.ok().body(resDto);
 	}
 }
 

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/ScrumController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/ScrumController.java
@@ -6,6 +6,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,6 +22,8 @@ import scrumpledpaper.agiler.common.PageResDto;
 import scrumpledpaper.agiler.note.dto.IdResDto;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.dto.ScrumResDto;
 import scrumpledpaper.agiler.note.service.ScrumService;
 
@@ -59,5 +62,16 @@ public class ScrumController {
 		@RequestBody @Valid NoteDeleteReqDto request) {
 		scrumService.deleteScrums(customUserDetails.getUserId(), projectUrl, request);
 		return ResponseEntity.noContent().build();
+	}
+
+	@PatchMapping("/{projectUrl}/scrums/{scrumId}")
+	public ResponseEntity<NoteParticipantResDto> updateScrumParticipants(
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable Long scrumId,
+		@RequestBody @Valid NoteParticipantUpdateReqDto request) {
+		NoteParticipantResDto response = scrumService.updateScrumParticipants(customUserDetails.getUserId(), projectUrl, scrumId, request);
+		return ResponseEntity.ok().body(response);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/WssController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/WssController.java
@@ -1,0 +1,29 @@
+package scrumpledpaper.agiler.note.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.auth.service.CustomUserDetails;
+import scrumpledpaper.agiler.note.dto.WssTokenResDto;
+import scrumpledpaper.agiler.note.service.WssService;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class WssController {
+	private final WssService wssService;
+
+	@GetMapping("/api/v1/projects/{projectUrl}/{docId}")
+	public ResponseEntity<WssTokenResDto> generateWssToken(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails,
+		@PathVariable String projectUrl,
+		@PathVariable String docId) {
+		String token = wssService.generateWssToken(customUserDetails.getUserId(), projectUrl, docId);
+		return ResponseEntity.ok(new WssTokenResDto(token));
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/WssController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/WssController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
+import scrumpledpaper.agiler.note.dto.RetroDetailResDto;
 import scrumpledpaper.agiler.note.dto.WssTokenResDto;
 import scrumpledpaper.agiler.note.service.WssService;
 
@@ -25,5 +26,12 @@ public class WssController {
 		@PathVariable String docId) {
 		String token = wssService.generateWssToken(customUserDetails.getUserId(), projectUrl, docId);
 		return ResponseEntity.ok(new WssTokenResDto(token));
+	}
+
+	@GetMapping("/internal/api/v1/docs/retro/{id}")
+	public ResponseEntity<RetroDetailResDto> getRetroDetail(
+		@PathVariable long id) {
+		RetroDetailResDto retroDetail = wssService.getRetroDetail(id);
+		return ResponseEntity.ok(retroDetail);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/WssController.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/controller/WssController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.auth.service.CustomUserDetails;
+import scrumpledpaper.agiler.note.dto.MeetingDetailResDto;
 import scrumpledpaper.agiler.note.dto.RetroDetailResDto;
 import scrumpledpaper.agiler.note.dto.WssTokenResDto;
 import scrumpledpaper.agiler.note.service.WssService;
@@ -33,5 +34,12 @@ public class WssController {
 		@PathVariable long id) {
 		RetroDetailResDto retroDetail = wssService.getRetroDetail(id);
 		return ResponseEntity.ok(retroDetail);
+	}
+
+	@GetMapping("/internal/api/v1/docs/meeting/{id}")
+	public ResponseEntity<MeetingDetailResDto> getMeetingDetail(
+		@PathVariable long id) {
+		MeetingDetailResDto meetingDetail = wssService.getMeetingDetail(id);
+		return ResponseEntity.ok(meetingDetail);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/MeetingDetailResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/MeetingDetailResDto.java
@@ -1,0 +1,18 @@
+package scrumpledpaper.agiler.note.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingDetailResDto(
+	long meetingId,
+	String title,
+	String contents,
+	LocalDateTime createdAt,
+	List<ParticipantResDto> participants
+) {
+		public record ParticipantResDto(
+			long profileId,
+			String nickname,
+			String imageUrl
+		) {}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/NoteParticipantResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/NoteParticipantResDto.java
@@ -1,0 +1,17 @@
+package scrumpledpaper.agiler.note.dto;
+
+import java.util.List;
+
+import scrumpledpaper.agiler.note.entity.NoteType;
+
+public record NoteParticipantResDto(
+	long noteId,
+	NoteType noteType,
+	List<ParticipantResDto> participants
+) {
+	public record ParticipantResDto(
+		long profileId,
+		String nickname,
+		String imageUrl
+	) {}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/NoteParticipantUpdateReqDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/NoteParticipantUpdateReqDto.java
@@ -1,0 +1,10 @@
+package scrumpledpaper.agiler.note.dto;
+
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record NoteParticipantUpdateReqDto(
+	@NotNull(message = "참여자 ID 목록은 필수입니다.")
+	List<Long> participantIds
+) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/RetroDetailResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/RetroDetailResDto.java
@@ -1,0 +1,18 @@
+package scrumpledpaper.agiler.note.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RetroDetailResDto(
+	long retroId,
+	String title,
+	String contents,
+	LocalDateTime createdAt,
+	List<ParticipantResDto> participants
+) {
+		public record ParticipantResDto(
+			long profileId,
+			String nickname,
+			String imageUrl
+		) {}
+	}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/ScrumDetailResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/ScrumDetailResDto.java
@@ -1,0 +1,31 @@
+package scrumpledpaper.agiler.note.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ScrumDetailResDto(
+	long scrumId,
+	String title,
+	String contents,
+	LocalDateTime createdAt,
+	List<ParticipantResDto> participants,
+	List<IssueResDto> issues
+) {
+	public record ParticipantResDto(
+		long profileId,
+		String nickname,
+		String imageUrl
+	) {}
+
+	public record IssueResDto(
+		long issueId,
+		String title,
+		List<AssigneeDto> assignees
+	) {}
+
+	public record AssigneeDto(
+		long profileId,
+		String nickname,
+		String imageUrl
+	) {}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/WssTokenResDto.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/dto/WssTokenResDto.java
@@ -1,0 +1,5 @@
+package scrumpledpaper.agiler.note.dto;
+
+public record WssTokenResDto(
+	String wssToken
+) {}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteType.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/entity/NoteType.java
@@ -1,0 +1,7 @@
+package scrumpledpaper.agiler.note.entity;
+
+public enum NoteType {
+	MEETING,
+	RETRO,
+	SCRUM
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/mapper/MeetingMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/mapper/MeetingMapper.java
@@ -8,6 +8,7 @@ import org.mapstruct.Mapping;
 
 import scrumpledpaper.agiler.note.dto.MeetingResDto;
 import scrumpledpaper.agiler.note.entity.Meeting;
+import scrumpledpaper.agiler.note.entity.MeetingProfile;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
@@ -57,4 +58,7 @@ public interface MeetingMapper {
 	@Mapping(target = "project", source = "project")
 	@Mapping(target = "meetingProfiles", ignore = true)
 	Meeting toEntity(Project project, String title, String contents);
+
+	@Mapping(target = "id", ignore = true)
+	MeetingProfile toMeetingProfileEntity(Meeting meeting, Profile profile);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/mapper/RetroMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/mapper/RetroMapper.java
@@ -8,6 +8,7 @@ import org.mapstruct.Mapping;
 
 import scrumpledpaper.agiler.note.dto.RetroResDto;
 import scrumpledpaper.agiler.note.entity.Retro;
+import scrumpledpaper.agiler.note.entity.RetroProfile;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.entity.RetroTemplate;
@@ -57,4 +58,7 @@ public interface RetroMapper {
 	@Mapping(target = "project", source = "project")
 	@Mapping(target = "retroProfiles", ignore = true)
 	Retro toEntity(Project project, String title, String contents);
+
+	@Mapping(target = "id", ignore = true)
+	RetroProfile toRetroProfileEntity(Retro retro, Profile profile);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/mapper/ScrumMapper.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/mapper/ScrumMapper.java
@@ -8,6 +8,7 @@ import org.mapstruct.Mapping;
 
 import scrumpledpaper.agiler.note.dto.ScrumResDto;
 import scrumpledpaper.agiler.note.entity.Scrum;
+import scrumpledpaper.agiler.note.entity.ScrumProfile;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.template.entity.ScrumTemplate;
@@ -57,4 +58,7 @@ public interface ScrumMapper {
 	@Mapping(target = "project", source = "project")
 	@Mapping(target = "scrumProfiles", ignore = true)
 	Scrum toEntity(Project project, String title, String contents);
+
+	@Mapping(target = "id", ignore = true)
+	ScrumProfile toScrumProfileEntity(Scrum scrum, Profile profile);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/MeetingProfileRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/MeetingProfileRepository.java
@@ -17,4 +17,12 @@ public interface MeetingProfileRepository extends JpaRepository<MeetingProfile, 
 	List<MeetingProfile> findAllByMeetingIdsWithProfile(List<Long> meetingIds);
 
 	List<MeetingProfile> findAllByMeetingId(Long id);
+
+	@Query("""
+		SELECT mp
+		FROM MeetingProfile mp
+		LEFT JOIN FETCH mp.profile p
+		WHERE mp.meeting.id = :id
+	""")
+	List<MeetingProfile> findAllByMeetingIdWithProfile(Long id);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/MeetingRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/MeetingRepository.java
@@ -14,4 +14,6 @@ public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 	Optional<Meeting> findTopByProjectIdOrderByCreatedAtDesc(Long projectId);
 
 	Optional<Meeting> findByIdAndProjectId(Long meetingId, Long projectId);
+
+	boolean existsByIdAndProjectId(Long meetingId, Long projectId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/RetroProfileRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/RetroProfileRepository.java
@@ -17,4 +17,12 @@ public interface RetroProfileRepository extends JpaRepository<RetroProfile, Long
 	List<RetroProfile> findAllByRetroIdsWithProfile(List<Long> retroIds);
 
 	List<RetroProfile> findAllByRetroId(Long id);
+
+	@Query("""
+		SELECT rp
+		FROM RetroProfile rp
+		LEFT JOIN FETCH rp.profile p
+		WHERE rp.retro.id = :id
+	""")
+	List<RetroProfile> findAllByRetroIdWithProfile(Long id);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/RetroRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/RetroRepository.java
@@ -13,4 +13,6 @@ public interface RetroRepository extends JpaRepository<Retro, Long> {
 	Optional<Retro> findTopByProjectIdOrderByCreatedAtDesc(Long id);
 
 	Optional<Retro> findByIdAndProjectId(long retroId, Long projectId);
+
+	boolean existsByIdAndProjectId(Long retroId, Long projectId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/ScrumRepository.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/repository/ScrumRepository.java
@@ -14,4 +14,6 @@ public interface ScrumRepository extends JpaRepository<Scrum, Long> {
 	Optional<Scrum> findTopByProjectIdOrderByCreatedAtDesc(Long id);
 
 	Optional<Scrum> findByIdAndProjectId(long scrumId, Long id);
+
+	boolean existsByIdAndProjectId(Long scrumId, Long projectId);
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
@@ -121,4 +121,11 @@ public class MeetingService {
 		return meetingRepository.findByIdAndProjectId(id, project.getId())
 			.orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
 	}
+
+	public void validateMeetingInProject(Long projectId, Long meetingId) {
+		boolean exists = meetingRepository.existsByIdAndProjectId(meetingId, projectId);
+		if (!exists) {
+			throw new CustomException(ErrorCode.NOTE_NOT_FOUND);
+		}
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
@@ -1,10 +1,12 @@
 package scrumpledpaper.agiler.note.service;
 
+import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import scrumpledpaper.agiler.common.PageValidator;
 import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
+import scrumpledpaper.agiler.note.dto.MeetingDetailResDto;
 import scrumpledpaper.agiler.note.dto.MeetingResDto;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
@@ -127,5 +130,40 @@ public class MeetingService {
 		if (!exists) {
 			throw new CustomException(ErrorCode.NOTE_NOT_FOUND);
 		}
+	}
+
+	public MeetingDetailResDto getMeetingDetail(long id) {
+		Meeting meeting = meetingRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
+
+		List<MeetingProfile> meetingProfiles = meetingProfileRepository.findAllByMeetingIdWithProfile(meeting.getId());
+
+		List<Long> imageIds = meetingProfiles.stream()
+			.map(MeetingProfile::getProfile)
+			.map(Profile::getImageId)
+			.distinct()
+			.toList();
+
+		Map<Long, String> imageUrls = imageService.getImageUrlsByIds(imageIds);
+
+		List<MeetingDetailResDto.ParticipantResDto> participants = meetingProfiles.stream()
+			.map(meetingProfile -> {
+				Profile profile = meetingProfile.getProfile();
+				String imageUrl = imageUrls.get(profile.getImageId());
+				return new MeetingDetailResDto.ParticipantResDto(
+					profile.getId(),
+					profile.getNickname(),
+					imageUrl
+				);
+			})
+			.toList();
+
+		return new MeetingDetailResDto(
+			meeting.getId(),
+			meeting.getTitle(),
+			meeting.getContents(),
+			meeting.getCreatedAt(),
+			participants
+		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/MeetingService.java
@@ -22,14 +22,18 @@ import scrumpledpaper.agiler.note.dto.MeetingDetailResDto;
 import scrumpledpaper.agiler.note.dto.MeetingResDto;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.entity.Meeting;
 import scrumpledpaper.agiler.note.entity.MeetingProfile;
+import scrumpledpaper.agiler.note.entity.NoteType;
 import scrumpledpaper.agiler.note.mapper.MeetingMapper;
 import scrumpledpaper.agiler.note.repository.MeetingProfileRepository;
 import scrumpledpaper.agiler.note.repository.MeetingRepository;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.project.service.ProfileService;
 import scrumpledpaper.agiler.project.service.ProjectValidator;
 import scrumpledpaper.agiler.template.entity.MeetingTemplate;
 import scrumpledpaper.agiler.template.service.MeetingTemplateService;
@@ -38,6 +42,7 @@ import scrumpledpaper.agiler.template.service.MeetingTemplateService;
 @RequiredArgsConstructor
 public class MeetingService {
 	private final ImageService imageService;
+	private final ProfileService profileService;
 	private final MeetingRepository meetingRepository;
 	private final MeetingTemplateService meetingTemplateService;
 	private final MeetingProfileRepository meetingProfileRepository;
@@ -164,6 +169,46 @@ public class MeetingService {
 			meeting.getContents(),
 			meeting.getCreatedAt(),
 			participants
+		);
+	}
+
+	public NoteParticipantResDto updateMeetingParticipants(long userId, String projectUrl, long meetingId, NoteParticipantUpdateReqDto request) {
+		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
+		Project project = context.project();
+
+		Meeting meeting = findByIdAndProject(meetingId, project);
+
+		List<MeetingProfile> existingMeetingProfiles = meetingProfileRepository.findAllByMeetingId(meetingId);
+		meetingProfileRepository.deleteAll(existingMeetingProfiles);
+
+		List<Profile> profiles = profileService.getProfilesByIds(request.participantIds());
+		List<MeetingProfile> newMeetingProfiles = profiles.stream()
+			.map(profile -> meetingMapper.toMeetingProfileEntity(meeting, profile))
+			.toList();
+		meetingProfileRepository.saveAll(newMeetingProfiles);
+
+		List<Long> imageIds = profiles.stream()
+			.map(Profile::getImageId)
+			.distinct()
+			.toList();
+
+		Map<Long, String> imageUrls = imageService.getImageUrlsByIds(imageIds);
+
+		List<NoteParticipantResDto.ParticipantResDto> participantResDtos = profiles.stream()
+			.map(profile -> {
+				String imageUrl = imageUrls.get(profile.getImageId());
+				return new NoteParticipantResDto.ParticipantResDto(
+					profile.getId(),
+					profile.getNickname(),
+					imageUrl
+				);
+			})
+			.toList();
+
+		return new NoteParticipantResDto(
+			meetingId,
+			NoteType.MEETING,
+			participantResDtos
 		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
@@ -121,4 +121,11 @@ public class RetroService {
 		return retroRepository.findByIdAndProjectId(retroId, project.getId())
 			.orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
 	}
+
+	public void validateRetroInProject(Long projectId, Long retroId) {
+		boolean exists = retroRepository.existsByIdAndProjectId(retroId, projectId);
+		if (!exists) {
+			throw new CustomException(ErrorCode.NOTE_NOT_FOUND);
+		}
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
@@ -18,6 +18,7 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.RetroDetailResDto;
 import scrumpledpaper.agiler.note.dto.RetroResDto;
 import scrumpledpaper.agiler.note.entity.Retro;
 import scrumpledpaper.agiler.note.entity.RetroProfile;
@@ -127,5 +128,40 @@ public class RetroService {
 		if (!exists) {
 			throw new CustomException(ErrorCode.NOTE_NOT_FOUND);
 		}
+	}
+
+	public RetroDetailResDto getRetroDetail(long id) {
+		Retro retro = retroRepository.findById(id)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
+
+		List<RetroProfile> retroProfiles = retroProfileRepository.findAllByRetroIdWithProfile(retro.getId());
+
+		List<Long> imageIds = retroProfiles.stream()
+			.map(RetroProfile::getProfile)
+			.map(Profile::getImageId)
+			.distinct()
+			.toList();
+
+		Map<Long, String> imageUrls = imageService.getImageUrlsByIds(imageIds);
+
+		List<RetroDetailResDto.ParticipantResDto> participants = retroProfiles.stream()
+			.map(retroProfile -> {
+				Profile profile = retroProfile.getProfile();
+				String imageUrl = imageUrls.get(profile.getImageId());
+				return new RetroDetailResDto.ParticipantResDto(
+					profile.getId(),
+					profile.getNickname(),
+					imageUrl
+				);
+			})
+			.toList();
+
+		return new RetroDetailResDto(
+			retro.getId(),
+			retro.getTitle(),
+			retro.getContents(),
+			retro.getCreatedAt(),
+			participants
+		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/RetroService.java
@@ -18,8 +18,11 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.dto.RetroDetailResDto;
 import scrumpledpaper.agiler.note.dto.RetroResDto;
+import scrumpledpaper.agiler.note.entity.NoteType;
 import scrumpledpaper.agiler.note.entity.Retro;
 import scrumpledpaper.agiler.note.entity.RetroProfile;
 import scrumpledpaper.agiler.note.mapper.RetroMapper;
@@ -28,6 +31,7 @@ import scrumpledpaper.agiler.note.repository.RetroRepository;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.project.service.ProfileService;
 import scrumpledpaper.agiler.project.service.ProjectValidator;
 import scrumpledpaper.agiler.template.entity.RetroTemplate;
 import scrumpledpaper.agiler.template.service.RetroTemplateService;
@@ -36,6 +40,7 @@ import scrumpledpaper.agiler.template.service.RetroTemplateService;
 @RequiredArgsConstructor
 public class RetroService {
 	private final ImageService imageService;
+	private final ProfileService profileService;
 	private final RetroRepository retroRepository;
 	private final RetroTemplateService retroTemplateService;
 	private final RetroProfileRepository retroProfileRepository;
@@ -162,6 +167,46 @@ public class RetroService {
 			retro.getContents(),
 			retro.getCreatedAt(),
 			participants
+		);
+	}
+
+	public NoteParticipantResDto updateRetroParticipants(long userId, String projectUrl, long retroId, NoteParticipantUpdateReqDto request) {
+		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
+		Project project = context.project();
+
+		Retro retro = findByIdAndProject(retroId, project);
+
+		List<RetroProfile> existingRetroProfiles = retroProfileRepository.findAllByRetroId(retro.getId());
+		retroProfileRepository.deleteAll(existingRetroProfiles);
+
+		List<Profile> profiles = profileService.getProfilesByIds(request.participantIds());
+		List<RetroProfile> newRetroProfiles = profiles.stream()
+			.map(profile -> retroMapper.toRetroProfileEntity(retro, profile))
+			.toList();
+		retroProfileRepository.saveAll(newRetroProfiles);
+
+		List<Long> imageIds = profiles.stream()
+			.map(Profile::getImageId)
+			.distinct()
+			.toList();
+
+		Map<Long, String> imageUrls = imageService.getImageUrlsByIds(imageIds);
+
+		List<NoteParticipantResDto.ParticipantResDto> participantDtos = profiles.stream()
+			.map(profile -> {
+				String imageUrl = imageUrls.get(profile.getImageId());
+				return new NoteParticipantResDto.ParticipantResDto(
+					profile.getId(),
+					profile.getNickname(),
+					imageUrl
+				);
+			})
+			.toList();
+
+		return new NoteParticipantResDto(
+			retroId,
+			NoteType.RETRO,
+			participantDtos
 		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/ScrumService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/ScrumService.java
@@ -121,4 +121,11 @@ public class ScrumService {
 		return scrumRepository.findByIdAndProjectId(scrumId, project.getId())
 			.orElseThrow(() -> new CustomException(ErrorCode.NOTE_NOT_FOUND));
 	}
+
+	public void validateScrumInProject(Long projectId, Long scrumId) {
+		boolean exists = scrumRepository.existsByIdAndProjectId(scrumId, projectId);
+		if (!exists) {
+			throw new CustomException(ErrorCode.NOTE_NOT_FOUND);
+		}
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/ScrumService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/ScrumService.java
@@ -18,7 +18,10 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.service.ImageService;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.dto.ScrumResDto;
+import scrumpledpaper.agiler.note.entity.NoteType;
 import scrumpledpaper.agiler.note.entity.Scrum;
 import scrumpledpaper.agiler.note.entity.ScrumProfile;
 import scrumpledpaper.agiler.note.mapper.ScrumMapper;
@@ -27,6 +30,7 @@ import scrumpledpaper.agiler.note.repository.ScrumRepository;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.project.service.ProfileService;
 import scrumpledpaper.agiler.project.service.ProjectValidator;
 import scrumpledpaper.agiler.template.entity.ScrumTemplate;
 import scrumpledpaper.agiler.template.service.ScrumTemplateService;
@@ -35,6 +39,7 @@ import scrumpledpaper.agiler.template.service.ScrumTemplateService;
 @RequiredArgsConstructor
 public class ScrumService {
 	private final ImageService imageService;
+	private final ProfileService profileService;
 	private final ScrumRepository scrumRepository;
 	private final ScrumTemplateService scrumTemplateService;
 	private final ScrumProfileRepository scrumProfileRepository;
@@ -127,5 +132,45 @@ public class ScrumService {
 		if (!exists) {
 			throw new CustomException(ErrorCode.NOTE_NOT_FOUND);
 		}
+	}
+
+	public NoteParticipantResDto updateScrumParticipants(long userId, String projectUrl, Long scrumId, NoteParticipantUpdateReqDto request) {
+		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
+		Project project = context.project();
+
+		Scrum scrum = findByIdAndProject(scrumId, project);
+
+		List<ScrumProfile> existingScrumProfiles = scrumProfileRepository.findAllByScrumId(scrum.getId());
+		scrumProfileRepository.deleteAll(existingScrumProfiles);
+
+		List<Profile> profiles = profileService.getProfilesByIds(request.participantIds());
+		List<ScrumProfile> scrumProfiles = profiles.stream()
+			.map(profile -> scrumMapper.toScrumProfileEntity(scrum, profile))
+			.toList();
+		scrumProfileRepository.saveAll(scrumProfiles);
+
+		List<Long> imageIds = profiles.stream()
+			.map(Profile::getImageId)
+			.distinct()
+			.toList();
+
+		Map<Long, String> imageUrls = imageService.getImageUrlsByIds(imageIds);
+
+		List<NoteParticipantResDto.ParticipantResDto> participantDtos = profiles.stream()
+			.map(profile -> {
+				String imageUrl = imageUrls.get(profile.getImageId());
+				return new NoteParticipantResDto.ParticipantResDto(
+					profile.getId(),
+					profile.getNickname(),
+					imageUrl
+				);
+			})
+			.toList();
+
+		return new NoteParticipantResDto(
+			scrum.getId(),
+			NoteType.SCRUM,
+			participantDtos
+		);
 	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/WssService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/WssService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.common.utils.WssTokenProvider;
+import scrumpledpaper.agiler.note.dto.MeetingDetailResDto;
 import scrumpledpaper.agiler.note.dto.RetroDetailResDto;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Project;
@@ -63,4 +64,8 @@ public class WssService {
 		return retroService.getRetroDetail(id);
 	}
 
+	@Transactional(readOnly = true)
+	public MeetingDetailResDto getMeetingDetail(long id) {
+		return meetingService.getMeetingDetail(id);
+	}
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/WssService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/WssService.java
@@ -1,0 +1,54 @@
+package scrumpledpaper.agiler.note.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import scrumpledpaper.agiler.common.exception.CustomException;
+import scrumpledpaper.agiler.common.exception.ErrorCode;
+import scrumpledpaper.agiler.common.utils.WssTokenProvider;
+import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
+import scrumpledpaper.agiler.project.entity.Project;
+import scrumpledpaper.agiler.project.service.ProjectValidator;
+
+@Service
+@RequiredArgsConstructor
+public class WssService {
+	private final ProjectValidator projectValidator;
+	private final MeetingService meetingService;
+	private final RetroService retroService;
+	private final ScrumService scrumService;
+	private final WssTokenProvider wssTokenProvider;
+
+	@Transactional(readOnly = true)
+	public String generateWssToken(Long userId, String projectUrl, String docId) {
+		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
+		Project project = context.project();
+
+		checkDocumentInProject(project, docId);
+		return wssTokenProvider.createWssToken(userId, docId);
+	}
+
+	private void checkDocumentInProject(Project project, String docId) {
+		String[] parts = docId.split("-", 2);
+		if (parts.length != 2) {
+			throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
+		}
+
+		String prefix = parts[0];
+		String numStr = parts[1];
+
+		try {
+			Long id = Long.parseLong(numStr);
+
+			switch (prefix) {
+				case "meeting" -> meetingService.validateMeetingInProject(project.getId(), id);
+				case "retro" -> retroService.validateRetroInProject(project.getId(), id);
+				case "scrum" -> scrumService.validateScrumInProject(project.getId(), id);
+				default -> throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
+			}
+		} catch (NumberFormatException e) {
+			throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
+		}
+	}
+}

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/WssService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/note/service/WssService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import scrumpledpaper.agiler.common.exception.CustomException;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.common.utils.WssTokenProvider;
+import scrumpledpaper.agiler.note.dto.RetroDetailResDto;
 import scrumpledpaper.agiler.project.dto.ProjectAccessContext;
 import scrumpledpaper.agiler.project.entity.Project;
 import scrumpledpaper.agiler.project.service.ProjectValidator;
@@ -20,6 +21,8 @@ public class WssService {
 	private final ScrumService scrumService;
 	private final WssTokenProvider wssTokenProvider;
 
+	private record ParsedDocId(String prefix, Long id) {}
+
 	@Transactional(readOnly = true)
 	public String generateWssToken(Long userId, String projectUrl, String docId) {
 		ProjectAccessContext context = projectValidator.validateAccess(userId, projectUrl);
@@ -29,26 +32,35 @@ public class WssService {
 		return wssTokenProvider.createWssToken(userId, docId);
 	}
 
+
 	private void checkDocumentInProject(Project project, String docId) {
+		ParsedDocId parsed = parseDocId(docId);
+
+		switch (parsed.prefix()) {
+			case "meeting" -> meetingService.validateMeetingInProject(project.getId(), parsed.id());
+			case "retro" -> retroService.validateRetroInProject(project.getId(), parsed.id());
+			case "scrum" -> scrumService.validateScrumInProject(project.getId(), parsed.id());
+			default -> throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
+		}
+	}
+
+	private ParsedDocId parseDocId(String docId) {
 		String[] parts = docId.split("-", 2);
 		if (parts.length != 2) {
 			throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
 		}
 
-		String prefix = parts[0];
-		String numStr = parts[1];
-
 		try {
-			Long id = Long.parseLong(numStr);
-
-			switch (prefix) {
-				case "meeting" -> meetingService.validateMeetingInProject(project.getId(), id);
-				case "retro" -> retroService.validateRetroInProject(project.getId(), id);
-				case "scrum" -> scrumService.validateScrumInProject(project.getId(), id);
-				default -> throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
-			}
+			Long id = Long.parseLong(parts[1]);
+			return new ParsedDocId(parts[0], id);
 		} catch (NumberFormatException e) {
 			throw new CustomException(ErrorCode.INVALID_DOCUMENT_ID);
 		}
 	}
+
+	@Transactional(readOnly = true)
+	public RetroDetailResDto getRetroDetail(long id) {
+		return retroService.getRetroDetail(id);
+	}
+
 }

--- a/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProfileService.java
+++ b/apps/backend/src/main/java/scrumpledpaper/agiler/project/service/ProfileService.java
@@ -188,4 +188,8 @@ public class ProfileService {
 			})
 			.toList();
 	}
+
+	public List<Profile> getProfilesByIds(List<Long> profileIds) {
+		return profileRepository.findAllById(profileIds);
+	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/kanban/IssueControllerTest.java
@@ -487,9 +487,7 @@ public class IssueControllerTest {
 			IssueUpdateReqDto updateReqDto = new IssueUpdateReqDto(
 				issue.getId(),
 				randomString(20),
-				randomString(50),
-				null,
-				null
+				randomString(50)
 			);
 
 			// when
@@ -517,9 +515,7 @@ public class IssueControllerTest {
 			IssueUpdateReqDto updateReqDto = new IssueUpdateReqDto(
 				9999L,
 				randomString(20),
-				randomString(50),
-				null,
-				null
+				randomString(50)
 			);
 
 			// when
@@ -562,9 +558,7 @@ public class IssueControllerTest {
 			IssueUpdateReqDto updateReqDto = new IssueUpdateReqDto(
 				issue.getId(),
 				randomString(20),
-				randomString(50),
-				null,
-				null
+				randomString(50)
 			);
 
 			// when

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/note/MeetingControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/note/MeetingControllerTest.java
@@ -28,6 +28,8 @@ import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.note.dto.MeetingResDto;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.entity.Meeting;
 import scrumpledpaper.agiler.project.entity.Profile;
 import scrumpledpaper.agiler.project.entity.Project;
@@ -394,6 +396,140 @@ public class MeetingControllerTest {
 			// when
 			String response = mockMvc.perform(
 					delete("/api/v1/projects/{projectUrl}/meetings", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("Update Meeting Participants Test")
+	class UpdateMeetingParticipantsTest {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - Meeting 참가자 업데이트 성공")
+		public void updateMeetingParticipantsSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Profile otherProfile = testDataFactory.createProfile(otherAuth.getUser(), project, Role.MEMBER);
+			Meeting meeting = testDataFactory.createMeetingWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(List.of(otherProfile.getId()));
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/meetings/{meetingId}", url, meeting.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			NoteParticipantResDto resDto = objectMapper.readValue(response, NoteParticipantResDto.class);
+			assertThat(resDto.participants()).hasSize(1);
+			assertThat(resDto.participants().get(0).profileId()).isEqualTo(otherProfile.getId());
+			assertThat(resDto.participants().get(0).nickname()).isEqualTo(otherProfile.getNickname());
+		}
+
+		@Test
+		@DisplayName("200 - Meeting 참가자 전체 삭제 성공")
+		public void updateMeetingParticipantsRemoveAllSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Meeting meeting = testDataFactory.createMeetingWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(List.of());
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/meetings/{meetingId}", url, meeting.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			NoteParticipantResDto resDto = objectMapper.readValue(response, NoteParticipantResDto.class);
+			assertThat(resDto.participants()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("403 - 프로젝트 참여자가 아닌 사용자가 Meeting 참가자 업데이트 시도")
+		public void updateMeetingParticipantsNotMember() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Meeting meeting = testDataFactory.createMeetingWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(List.of());
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/meetings/{meetingId}", url, meeting.getId())
+						.cookie(new Cookie("accessToken", otherAuth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트의 Meeting 참가자 업데이트 시도")
+		public void updateMeetingParticipantsProjectNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "non-existent-url";
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(List.of());
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/meetings/{meetingId}", url, 1L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 Meeting 참가자 업데이트 시도")
+		public void updateMeetingParticipantsMeetingNotFound() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(List.of());
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/meetings/{meetingId}", url, 999L)
 						.cookie(new Cookie("accessToken", auth.getToken()))
 						.contentType("application/json")
 						.content(objectMapper.writeValueAsString(reqDto)))

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/note/RetroControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/note/RetroControllerTest.java
@@ -27,6 +27,8 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.dto.RetroResDto;
 import scrumpledpaper.agiler.note.entity.Retro;
 import scrumpledpaper.agiler.project.entity.Profile;
@@ -400,6 +402,151 @@ public class RetroControllerTest {
 			// when
 			String response = mockMvc.perform(
 					delete("/api/v1/projects/{projectUrl}/retros", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("Update Retro Participants Test")
+	class UpdateRetroParticipantsTest {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - Retro 참가자 업데이트 성공")
+		public void updateRetroParticipantsSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Profile otherProfile = testDataFactory.createProfile(otherAuth.getUser(), project, Role.MEMBER);
+			Retro retro = testDataFactory.createRetroWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of(otherProfile.getId())
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/retros/{retroId}", url, retro.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			NoteParticipantResDto resDto = objectMapper.readValue(response, NoteParticipantResDto.class);
+			assertThat(resDto.participants()).hasSize(1);
+			assertThat(resDto.participants().get(0).profileId()).isEqualTo(otherProfile.getId());
+			assertThat(resDto.participants().get(0).nickname()).isEqualTo(otherProfile.getNickname());
+		}
+
+		@Test
+		@DisplayName("200 - Retro 참가자 업데이트 성공 (빈 참가자 리스트)")
+		public void updateRetroParticipantsEmptySuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Retro retro = testDataFactory.createRetroWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/retros/{retroId}", url, retro.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			NoteParticipantResDto resDto = objectMapper.readValue(response, NoteParticipantResDto.class);
+			assertThat(resDto.participants()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("403 - 프로젝트 참여자가 아닌 사용자의 Retro 참가자 업데이트 실패")
+		public void updateRetroParticipantsForbiddenFail() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Retro retro = testDataFactory.createRetroWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/retros/{retroId}", url, retro.getId())
+						.cookie(new Cookie("accessToken", otherAuth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트의 Retro 참가자 업데이트 실패")
+		public void updateRetroParticipantsNotFoundFail() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "non-existent-url";
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/retros/{retroId}", url, 1L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 Retro 참가자 업데이트 실패")
+		public void updateRetroParticipantsRetroNotFoundFail() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Long nonExistentRetroId = 9999L;
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/retros/{retroId}", url, nonExistentRetroId)
 						.cookie(new Cookie("accessToken", auth.getToken()))
 						.contentType("application/json")
 						.content(objectMapper.writeValueAsString(reqDto)))

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/note/ScrumControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/note/ScrumControllerTest.java
@@ -27,6 +27,8 @@ import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.image.entity.Image;
 import scrumpledpaper.agiler.note.dto.NoteCreateReqDto;
 import scrumpledpaper.agiler.note.dto.NoteDeleteReqDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantResDto;
+import scrumpledpaper.agiler.note.dto.NoteParticipantUpdateReqDto;
 import scrumpledpaper.agiler.note.dto.ScrumResDto;
 import scrumpledpaper.agiler.note.entity.Scrum;
 import scrumpledpaper.agiler.project.entity.Profile;
@@ -399,6 +401,151 @@ public class ScrumControllerTest {
 			// when
 			String response = mockMvc.perform(
 					delete("/api/v1/projects/{projectUrl}/scrums", url)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("Update Scrum Participants Test")
+	class UpdateScrumParticipantsTest {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - Scrum 참가자 업데이트 성공")
+		public void updateScrumParticipantsSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Profile otherProfile = testDataFactory.createProfile(otherAuth.getUser(), project, Role.MEMBER);
+			Scrum scrum = testDataFactory.createScrumWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of(otherProfile.getId())
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/scrums/{scrumId}", url, scrum.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			NoteParticipantResDto resDto = objectMapper.readValue(response, NoteParticipantResDto.class);
+			assertThat(resDto.participants()).hasSize(1);
+			assertThat(resDto.participants().get(0).profileId()).isEqualTo(otherProfile.getId());
+			assertThat(resDto.participants().get(0).nickname()).isEqualTo(otherProfile.getNickname());
+		}
+
+		@Test
+		@DisplayName("200 - Scrum 참가자 업데이트 성공 (빈 참가자 리스트)")
+		public void updateScrumParticipantsEmptySuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Scrum scrum = testDataFactory.createScrumWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/scrums/{scrumId}", url, scrum.getId())
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			NoteParticipantResDto resDto = objectMapper.readValue(response, NoteParticipantResDto.class);
+			assertThat(resDto.participants()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("403 - 프로젝트 참여자가 아닌 사용자의 Scrum 참가자 업데이트 실패")
+		public void updateScrumParticipantsForbiddenFail() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Scrum scrum = testDataFactory.createScrumWithParticipants(project, List.of(authProfile));
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/scrums/{scrumId}", url, scrum.getId())
+						.cookie(new Cookie("accessToken", otherAuth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 프로젝트의 Scrum 참가자 업데이트 실패")
+		public void updateScrumParticipantsNotFoundFail() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "non-existent-url";
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/scrums/{scrumId}", url, 1L)
+						.cookie(new Cookie("accessToken", auth.getToken()))
+						.contentType("application/json")
+						.content(objectMapper.writeValueAsString(reqDto)))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_FOUND.getMessage());
+		}
+
+		@Test
+		@DisplayName("404 - 존재하지 않는 Scrum 참가자 업데이트 실패")
+		public void updateScrumParticipantsScrumNotFoundFail() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Long nonExistentScrumId = 9999L;
+			NoteParticipantUpdateReqDto reqDto = new NoteParticipantUpdateReqDto(
+				List.of()
+			);
+
+			// when
+			String response = mockMvc.perform(
+					patch("/api/v1/projects/{projectUrl}/scrums/{scrumId}", url, nonExistentScrumId)
 						.cookie(new Cookie("accessToken", auth.getToken()))
 						.contentType("application/json")
 						.content(objectMapper.writeValueAsString(reqDto)))

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/note/WssControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/note/WssControllerTest.java
@@ -1,0 +1,202 @@
+package scrumpledpaper.agiler.note;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import scrumpledpaper.agiler.annotation.IntegrationTest;
+import scrumpledpaper.agiler.common.AuthContext;
+import scrumpledpaper.agiler.common.TestDataFactory;
+import scrumpledpaper.agiler.common.exception.ErrorCode;
+import scrumpledpaper.agiler.common.utils.WssTokenProvider;
+import scrumpledpaper.agiler.image.entity.Image;
+import scrumpledpaper.agiler.note.entity.Meeting;
+import scrumpledpaper.agiler.note.entity.Retro;
+import scrumpledpaper.agiler.project.entity.Profile;
+import scrumpledpaper.agiler.project.entity.Project;
+
+@IntegrationTest
+@Transactional
+public class WssControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@Autowired
+	private TestDataFactory testDataFactory;
+	@Autowired
+	private WssTokenProvider wssTokenProvider;
+	Image defaultImage;
+
+	@Nested
+	@DisplayName("Get Wss Token API")
+	class GetWssTokenApi {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - Wss 토큰 발급 성공 - meeting")
+		public void meetingWssTokenSuccess() throws Exception {
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
+			Meeting meeting = testDataFactory.createMeetingWithParticipants(project, List.of(authProfile));
+			String docId = "meeting-" + meeting.getId();
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/{docId}", url, docId)
+						.cookie(new Cookie("accessToken", auth.getToken())))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).isNotBlank();
+
+			String token = objectMapper.readTree(response).get("wssToken").asText();
+			Claims claims = wssTokenProvider.getClaims(token);
+
+			assertThat(claims.getSubject()).isEqualTo(auth.getUser().getId().toString());
+			assertThat(claims.get("docId", String.class)).isEqualTo(docId);
+			assertThat(claims.getIssuedAt()).isNotNull();
+			assertThat(claims.getExpiration()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("200 - Wss 토큰 발급 성공 - retro")
+		public void retroWssTokenSuccess() throws Exception {
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
+			Retro retro = testDataFactory.createRetroWithParticipants(project, List.of(authProfile));
+			String docId = "retro-" + retro.getId();
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/{docId}", url, docId)
+						.cookie(new Cookie("accessToken", auth.getToken())))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).isNotBlank();
+
+			String token = objectMapper.readTree(response).get("wssToken").asText();
+			Claims claims = wssTokenProvider.getClaims(token);
+
+			assertThat(claims.getSubject()).isEqualTo(auth.getUser().getId().toString());
+			assertThat(claims.get("docId", String.class)).isEqualTo(docId);
+			assertThat(claims.getIssuedAt()).isNotNull();
+			assertThat(claims.getExpiration()).isNotNull();
+		}
+
+		@Test
+		@DisplayName("200 - Wss 토큰 발급 성공 - scrum")
+		public void scrumWssTokenSuccess() throws Exception {
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			String docId =
+				"scrum-" + testDataFactory.createScrumWithParticipants(project, List.of(authProfile)).getId();
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/{docId}", url, docId)
+						.cookie(new Cookie("accessToken", auth.getToken())))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).isNotBlank();
+
+			String token = objectMapper.readTree(response).get("wssToken").asText();
+			Claims claims = wssTokenProvider.getClaims(token);
+
+			assertThat(claims.getSubject()).isEqualTo(auth.getUser().getId().toString());
+			assertThat(claims.get("docId", String.class)).isEqualTo(docId);
+			assertThat(claims.getIssuedAt()).isNotNull();
+			assertThat(claims.getExpiration()).isNotNull();
+		}
+
+		@ParameterizedTest
+		@DisplayName("404 - Wss 토큰 발급 실패 - 존재하지 않는 문서")
+		@ValueSource(strings = { "meeting-9999", "retro-9999", "scrum-9999" })
+		public void wssTokenFail_NotFoundDocument(String docId) throws Exception {
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/{docId}", url, docId)
+						.cookie(new Cookie("accessToken", auth.getToken())))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
+		}
+
+		@ParameterizedTest
+		@DisplayName("400 - Wss 토큰 발급 실패 - 잘못된 문서 ID 포맷")
+		@ValueSource(strings = { "meeting-", "retro-abc", "scrum-12ab", "unknown-123", "invalidformat", "1-2-3" })
+		public void wssTokenFail_InvalidDocumentIdFormat(String docId) throws Exception {
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/{docId}", url, docId)
+						.cookie(new Cookie("accessToken", auth.getToken())))
+				.andExpect(status().isBadRequest())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.INVALID_DOCUMENT_ID.getMessage());
+		}
+
+		@Test
+		@DisplayName("403 - Wss 토큰 발급 실패 - 문서에 대한 접근 권한 없음")
+		public void wssTokenFail_NoAccessToDocument() throws Exception {
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			AuthContext otherAuth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Meeting meeting = testDataFactory.createMeetingWithParticipants(project, List.of());
+			String docId = "meeting-" + meeting.getId();
+
+			// when
+			String response = mockMvc.perform(
+					get("/api/v1/projects/{projectUrl}/{docId}", url, docId)
+						.cookie(new Cookie("accessToken", otherAuth.getToken())))
+				.andExpect(status().isForbidden())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+	}
+}

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/note/WssControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/note/WssControllerTest.java
@@ -23,6 +23,7 @@ import jakarta.servlet.http.Cookie;
 import scrumpledpaper.agiler.annotation.IntegrationTest;
 import scrumpledpaper.agiler.common.AuthContext;
 import scrumpledpaper.agiler.common.TestDataFactory;
+import scrumpledpaper.agiler.common.config.AppProperties;
 import scrumpledpaper.agiler.common.exception.ErrorCode;
 import scrumpledpaper.agiler.common.utils.WssTokenProvider;
 import scrumpledpaper.agiler.image.entity.Image;
@@ -42,6 +43,8 @@ public class WssControllerTest {
 	private TestDataFactory testDataFactory;
 	@Autowired
 	private WssTokenProvider wssTokenProvider;
+	@Autowired
+	private AppProperties appProperties;
 	Image defaultImage;
 
 	@Nested
@@ -197,6 +200,62 @@ public class WssControllerTest {
 
 			// then
 			assertThat(response).contains(ErrorCode.PROJECT_NOT_MEMBER.getMessage());
+		}
+	}
+
+	@Nested
+	@DisplayName("Get Retro Detail API")
+	class GetRetroDetailApi {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - 회고 상세 조회 성공")
+		public void getRetroDetailSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(), project.getId());
+			Retro retro = testDataFactory.createRetroWithParticipants(project, List.of(authProfile));
+			String apiKey = appProperties.getApi().getKey();
+
+			// when
+			String response = mockMvc.perform(
+					get("/internal/api/v1/docs/retro/{id}", retro.getId())
+						.header("X-API-KEY", apiKey))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).isNotBlank();
+			assertThat(response).contains(retro.getId().toString());
+			assertThat(response).contains(retro.getTitle());
+			assertThat(response).contains(retro.getContents());
+			assertThat(response).contains(authProfile.getId().toString());
+			assertThat(response).contains(authProfile.getNickname());
+		}
+
+		@Test
+		@DisplayName("404 - 회고 상세 조회 실패 - 존재하지 않는 회고")
+		public void getRetroDetailFail_NotFoundRetro() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			String apiKey = appProperties.getApi().getKey();
+
+			// when
+			String response = mockMvc.perform(
+					get("/internal/api/v1/docs/retro/{id}", 9999L)
+						.header("X-API-KEY", apiKey))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
 		}
 	}
 }

--- a/apps/backend/src/test/java/scrumpledpaper/agiler/note/WssControllerTest.java
+++ b/apps/backend/src/test/java/scrumpledpaper/agiler/note/WssControllerTest.java
@@ -258,4 +258,61 @@ public class WssControllerTest {
 			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
 		}
 	}
+
+	@Nested
+	@DisplayName("Get Meeting Detail API")
+	class GetMeetingDetailApi {
+		@BeforeEach
+		void beforeEach() {
+			defaultImage = testDataFactory.createDefaultImage();
+		}
+
+		@Test
+		@DisplayName("200 - 회의 상세 조회 성공")
+		public void getMeetingDetailSuccess() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			Project project = testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			Profile authProfile = testDataFactory.findProfileByUserIdAndProjectId(auth.getUser().getId(),
+				project.getId());
+			Meeting meeting = testDataFactory.createMeetingWithParticipants(project, List.of(authProfile));
+			String apiKey = appProperties.getApi().getKey();
+
+			// when
+			String response = mockMvc.perform(
+					get("/internal/api/v1/docs/meeting/{id}", meeting.getId())
+						.header("X-API-KEY", apiKey))
+				.andExpect(status().isOk())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).isNotBlank();
+			assertThat(response).contains(meeting.getId().toString());
+			assertThat(response).contains(meeting.getTitle());
+			assertThat(response).contains(meeting.getContents());
+			assertThat(response).contains(authProfile.getId().toString());
+			assertThat(response).contains(authProfile.getNickname());
+		}
+
+		@Test
+		@DisplayName("404 - 회의 상세 조회 실패 - 존재하지 않는 회의")
+		public void getMeetingDetailFail_NotFoundMeeting() throws Exception {
+			// given
+			AuthContext auth = testDataFactory.createAuth(defaultImage);
+			String url = "test-url";
+			testDataFactory.createProjectAndOwnerProfile(url, auth.getUser());
+			String apiKey = appProperties.getApi().getKey();
+
+			// when
+			String response = mockMvc.perform(
+					get("/internal/api/v1/docs/meeting/{id}", 9999L)
+						.header("X-API-KEY", apiKey))
+				.andExpect(status().isNotFound())
+				.andReturn().getResponse().getContentAsString();
+
+			// then
+			assertThat(response).contains(ErrorCode.NOTE_NOT_FOUND.getMessage());
+		}
+	}
 }

--- a/apps/backend/src/test/resources/application-test.yml
+++ b/apps/backend/src/test/resources/application-test.yml
@@ -59,6 +59,9 @@ app:
     refreshTokenSecret: "scrumpledpaperanotherdummydummysecretkey"
     token-expiry: 86400000
     refresh-token-expiry: 604800000
+  api:
+    key: "scumpleddummypaperdummyapikeydummykey"
+    wss-token-expiry: 300000
   oauth2:
     authorizedRedirectUris:
       - http://localhost:3000/oauth2/redirect

--- a/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
+++ b/apps/backend/src/testFixtures/java/scrumpledpaper/agiler/common/TestDataFactory.java
@@ -473,11 +473,12 @@ public class TestDataFactory {
 		return issueRepository.findAllByProjectId(id);
 	}
 
-	public void createMeetingWithParticipants(Project project, List<Profile> participants) {
+	public Meeting createMeetingWithParticipants(Project project, List<Profile> participants) {
 		Meeting savedMeeting = meetingRepository.save(MeetingFixture.createMeeting(project));
 		meetingProfileRepository.saveAll(
 			MeetingFixture.createMeetingProfiles(savedMeeting, participants)
 		);
+		return savedMeeting;
 	}
 
 	public Page<Meeting> findMeetingsByProjectIdPaged(Long id, int page, int size) {
@@ -511,11 +512,12 @@ public class TestDataFactory {
 		return retroRepository.findAllByProjectId(id, pageable);
 	}
 
-	public void createRetroWithParticipants(Project project, List<Profile> participants) {
+	public Retro createRetroWithParticipants(Project project, List<Profile> participants) {
 		Retro savedRetro = retroRepository.save(RetroFixture.createRetro(project));
 		retroProfileRepository.saveAll(
 			RetroFixture.createRetroProfiles(savedRetro, participants)
 		);
+		return savedRetro;
 	}
 
 	public Retro findByLatestRetroByProjectId(Long id) {


### PR DESCRIPTION
## 🚀 기능 개요

- Wss Token 발급 API 구현
- Note Participants Update API 구현
- Note Internal API 구현

## 🧩 작업 사항

- Front와 Wss 서버간의 통신에 사용할 Wss 토큰을 발급하는 API를 구현했습니다.
  - 이때 Wss Token은 wss서버와 공유하는 apikey로 변환합니다.
- Note(Meeting, Retro, Scrum)의 참여자를 Update하는 API 구현 및 테스트 코드 작성
- Note(Meeting, Retro)의 상세정보를 조회하는 Internal API를 구현 및 테스트 코드 작성
- Internal API 용 Spring Security와 Filter를 추가했습니다.

## 🔄 변경 로직
- Issue Update시 수정하지 않던 StartAt, DueAt을 Request에서 삭제했습니다.
- application-test.yml에 내부 API용 apiKey를 추가했습니다.
- SnapShot Cookie의 Value값을 만료시간으로 변경했습니다.

## 🗂️ 이슈 번호
-closed #126 